### PR TITLE
chore: move `prettier`'s `.md` config to `.prettierrc`

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -21,9 +21,7 @@ module.exports = {
     // lint-staged appends all matched files at the end of the command
     // https://github.com/lint-staged/lint-staged?tab=readme-ov-file#what-commands-are-supported
     '*.json': 'prettier --write',
-
-    // Override `--tab-width` to indent Markdown list items properly
-    '*.md': 'prettier --tab-width 2 --write',
+    '*.md': 'prettier --write',
 
     // Check `package.json` files have appropriate `Apache-2.0` license and author
     // https://github.com/lint-staged/lint-staged?tab=readme-ov-file#example-wrap-filenames-in-single-quotes-and-run-once-per-file

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,13 @@
     "semi": true,
     "singleQuote": true,
     "arrowParens": "avoid",
-    "quoteProps": "preserve"
+    "quoteProps": "preserve",
+    "overrides": [
+        {
+            "files": "*.md",
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }


### PR DESCRIPTION
**Description**:

This PR moves `prettier`'s `.md` specific config to `.prettierrc`.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #112.
