### PR TITLE
feature: preventing multiple requests for the same token data (#48)

### DIFF
--- a/src/HtsSystemContractFFI.sol
+++ b/src/HtsSystemContractFFI.sol
@@ -90,23 +90,15 @@ contract HtsSystemContractFFI is HtsSystemContract {
         if (initialized) {
             return;
         }
-        // TODO: Avoid making many requests to the Mirror Node
-        HVM.storeString(address(this), HVM.getSlot("name"), MirrorNodeLib.getTokenStringData("name"));
-        HVM.storeString(
-            address(this),
-            HVM.getSlot("symbol"),
-            MirrorNodeLib.getTokenStringData("symbol")
-        );
-        vm.store(
-            address(this),
-            bytes32(HVM.getSlot("decimals")),
-            bytes32(vm.parseUint(MirrorNodeLib.getTokenStringData("decimals")))
-        );
-        vm.store(
-            address(this),
-            bytes32(HVM.getSlot("totalSupply")),
-            bytes32(vm.parseUint(MirrorNodeLib.getTokenStringData("total_supply")))
-        );
+        string memory json = string(MirrorNodeLib.getTokenData());
+        string memory tokenName = abi.decode(vm.parseJson(json, string(abi.encodePacked(".", "name"))), (string));
+        string memory tokenSymbol = abi.decode(vm.parseJson(json, string(abi.encodePacked(".", "symbol"))), (string));
+        uint256 totalSupply = vm.parseUint(abi.decode(vm.parseJson(json, ".total_supply"), (string)));
+        uint256 decimals = uint8(vm.parseUint(abi.decode(vm.parseJson(json, ".decimals"), (string))));
+        HVM.storeString(address(this), HVM.getSlot("name"), tokenName);
+        HVM.storeString(address(this), HVM.getSlot("symbol"), tokenSymbol);
+        vm.store(address(this), bytes32(HVM.getSlot("decimals")), bytes32(decimals));
+        vm.store(address(this), bytes32(HVM.getSlot("totalSupply")), bytes32(totalSupply));
         vm.store(address(this), bytes32(HVM.getSlot("initialized")), bytes32(uint256(1)));
     }
 

--- a/src/MirrorNodeLib.sol
+++ b/src/MirrorNodeLib.sol
@@ -9,15 +9,14 @@ library MirrorNodeLib {
 
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function getTokenStringData(string memory field) internal returns (string memory) {
+    function getTokenData() internal returns (string memory) {
         (uint256 status, bytes memory data) = string(abi.encodePacked(
             _mirrorNodeUrl(),
             "tokens/0.0.",
             vm.toString(uint160(address(this)))
         )).get();
         require(status == 200, "Failed to get token data from the Hedera MirrorNode");
-        string memory json = string(data);
-        return abi.decode(vm.parseJson(json, string(abi.encodePacked(".", field))), (string));
+        return string(data);
     }
 
     function getAllowance(address owner, address spender) internal returns (uint256) {


### PR DESCRIPTION
**Description**:
Only one request will be made to get all of the token fields, instead of querying each of them separately. It will limit the number of requests to the mirror node.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
