### PR TITLE
feat: implement storage layout offsets for Foundry and Hardhat

### DIFF
--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -6,7 +6,7 @@ import {HtsSystemContract, HTS_ADDRESS} from "./HtsSystemContract.sol";
 import {IERC20} from "./IERC20.sol";
 import {MirrorNode} from "./MirrorNode.sol";
 import {IMirrorNodeResponses} from "./IMirrorNodeResponses.sol";
-import {storeAddress, storeBool, storeBytes, storeInt, storeInt64, storeString, storeUint} from "./StrStore.sol";
+import {storeAddress, storeBool, storeBytes, storeInt64, storeString, storeUint} from "./StrStore.sol";
 
 contract HtsSystemContractJson is HtsSystemContract {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));

--- a/contracts/IHederaTokenService.sol
+++ b/contracts/IHederaTokenService.sol
@@ -1,20 +1,82 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
+// pragma experimental ABIEncoderV2;
 
 interface IHederaTokenService {
+
+    // /// Transfers cryptocurrency among two or more accounts by making the desired adjustments to their
+    // /// balances. Each transfer list can specify up to 10 adjustments. Each negative amount is withdrawn
+    // /// from the corresponding account (a sender), and each positive one is added to the corresponding
+    // /// account (a receiver). The amounts list must sum to zero. Each amount is a number of tinybars
+    // /// (there are 100,000,000 tinybars in one hbar).  If any sender account fails to have sufficient
+    // /// hbars, then the entire transaction fails, and none of those transfers occur, though the
+    // /// transaction fee is still charged. This transaction must be signed by the keys for all the sending
+    // /// accounts, and for any receiving accounts that have receiverSigRequired == true. The signatures
+    // /// are in the same order as the accounts, skipping those accounts that don't need a signature.
+    // /// @custom:version 0.3.0 previous version did not include isApproval
+    // struct AccountAmount {
+    //     // The Account ID, as a solidity address, that sends/receives cryptocurrency or tokens
+    //     address accountID;
+
+    //     // The amount of  the lowest denomination of the given token that
+    //     // the account sends(negative) or receives(positive)
+    //     int64 amount;
+
+    //     // If true then the transfer is expected to be an approved allowance and the
+    //     // accountID is expected to be the owner. The default is false (omitted).
+    //     bool isApproval;
+    // }
+
+    // /// A sender account, a receiver account, and the serial number of an NFT of a Token with
+    // /// NON_FUNGIBLE_UNIQUE type. When minting NFTs the sender will be the default AccountID instance
+    // /// (0.0.0 aka 0x0) and when burning NFTs, the receiver will be the default AccountID instance.
+    // /// @custom:version 0.3.0 previous version did not include isApproval
+    // struct NftTransfer {
+    //     // The solidity address of the sender
+    //     address senderAccountID;
+
+    //     // The solidity address of the receiver
+    //     address receiverAccountID;
+
+    //     // The serial number of the NFT
+    //     int64 serialNumber;
+
+    //     // If true then the transfer is expected to be an approved allowance and the
+    //     // accountID is expected to be the owner. The default is false (omitted).
+    //     bool isApproval;
+    // }
+
+    // struct TokenTransferList {
+    //     // The ID of the token as a solidity address
+    //     address token;
+
+    //     // Applicable to tokens of type FUNGIBLE_COMMON. Multiple list of AccountAmounts, each of which
+    //     // has an account and amount.
+    //     AccountAmount[] transfers;
+
+    //     // Applicable to tokens of type NON_FUNGIBLE_UNIQUE. Multiple list of NftTransfers, each of
+    //     // which has a sender and receiver account, including the serial number of the NFT
+    //     NftTransfer[] nftTransfers;
+    // }
+
+    // struct TransferList {
+    //     // Multiple list of AccountAmounts, each of which has an account and amount.
+    //     // Used to transfer hbars between the accounts in the list.
+    //     AccountAmount[] transfers;
+    // }
 
     /// Expiry properties of a Hedera token - second, autoRenewAccount, autoRenewPeriod
     struct Expiry {
         // The epoch second at which the token should expire; if an auto-renew account and period are
         // specified, this is coerced to the current epoch second plus the autoRenewPeriod
-        int256 second;
+        int64 second;
 
         // ID of an account which will be automatically charged to renew the token's expiration, at
         // autoRenewPeriod interval, expressed as a solidity address
         address autoRenewAccount;
 
         // The interval at which the auto-renew account will be charged to extend the token's expiry
-        int256 autoRenewPeriod;
+        int64 autoRenewPeriod;
     }
 
     /// A Key can be a public key from either the Ed25519 or ECDSA(secp256k1) signature schemes, where
@@ -29,14 +91,14 @@ interface IHederaTokenService {
     /// Exactly one of the possible values should be populated in order for the Key to be valid.
     struct KeyValue {
 
+        // if set to true, the key of the calling Hedera account will be inherited as the token key
+        bool inheritAccountKey;
+
         // smart contract instance that is authorized as if it had signed with a key
         address contractId;
 
         // Ed25519 public key bytes
         bytes ed25519;
-
-        // if set to true, the key of the calling Hedera account will be inherited as the token key
-        bool inheritAccountKey;
 
         // Compressed ECDSA(secp256k1) public key bytes
         bytes ECDSA_secp256k1;
@@ -94,7 +156,7 @@ interface IHederaTokenService {
         // IWA Compatibility. Depends on TokenSupplyType. For tokens of type FUNGIBLE_COMMON - the
         // maximum number of tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE -
         // the maximum number of NFTs (serial numbers) that can be minted. This field can never be changed!
-        int256 maxSupply;
+        int64 maxSupply;
 
         // The default Freeze status (frozen or unfrozen) of Hedera accounts relative to this token. If
         // true, an account must be unfrozen before it can receive the token
@@ -113,22 +175,22 @@ interface IHederaTokenService {
         HederaToken token;
 
         /// The number of tokens (fungible) or serials (non-fungible) of the token
-        int256 totalSupply;
+        int64 totalSupply;
 
         /// Specifies whether the token is deleted or not
         bool deleted;
 
-        /// The fixed fees collected when transferring the token
-        FixedFee[] fixedFees;
-
         /// Specifies whether the token kyc was defaulted with KycNotApplicable (true) or Revoked (false)
         bool defaultKycStatus;
 
-        /// The fractional fees collected when transferring the token
-        FractionalFee[] fractionalFees;
-
         /// Specifies whether the token is currently paused or not
         bool pauseStatus;
+
+        /// The fixed fees collected when transferring the token
+        FixedFee[] fixedFees;
+
+        /// The fractional fees collected when transferring the token
+        FractionalFee[] fractionalFees;
 
         /// The royalty fees collected when transferring the token
         RoyaltyFee[] royaltyFees;
@@ -137,50 +199,73 @@ interface IHederaTokenService {
         string ledgerId;
     }
 
+    // /// Additional fungible properties of a Hedera Token.
+    // struct FungibleTokenInfo {
+    //     /// The shared hedera token info
+    //     TokenInfo tokenInfo;
+
+    //     /// The number of decimal places a token is divisible by
+    //     int32 decimals;
+    // }
+
+    // /// Additional non fungible properties of a Hedera Token.
+    // struct NonFungibleTokenInfo {
+    //     /// The shared hedera token info
+    //     TokenInfo tokenInfo;
+
+    //     /// The serial number of the nft
+    //     int64 serialNumber;
+
+    //     /// The account id specifying the owner of the non fungible token
+    //     address ownerId;
+
+    //     /// The epoch second at which the token was created.
+    //     int64 creationTime;
+
+    //     /// The unique metadata of the NFT
+    //     bytes metadata;
+
+    //     /// The account id specifying an account that has been granted spending permissions on this nft
+    //     address spenderId;
+    // }
+
     /// A fixed number of units (hbar or token) to assess as a fee during a transfer of
     /// units of the token to which this fixed fee is attached. The denomination of
     /// the fee depends on the values of tokenId, useHbarsForPayment and
     /// useCurrentTokenForPayment. Exactly one of the values should be set.
     struct FixedFee {
 
-        // The ID of the account to receive the custom fee, expressed as a solidity address
-        address feeCollector;
-
-        int256 amount;
+        int64 amount;
 
         // Specifies ID of token that should be used for fixed fee denomination
         address tokenId;
 
-        // Puts a gap in the struct to prevent offsets
-        uint256 __gap1;
-
         // Specifies this fixed fee should be denominated in Hbar
         bool useHbarsForPayment;
 
-        // Puts a gap in the struct to prevent offsets
-        uint256 __gap2;
-
         // Specifies this fixed fee should be denominated in the Token currently being created
         bool useCurrentTokenForPayment;
+
+        // The ID of the account to receive the custom fee, expressed as a solidity address
+        address feeCollector;
     }
 
     /// A fraction of the transferred units of a token to assess as a fee. The amount assessed will never
     /// be less than the given minimumAmount, and never greater than the given maximumAmount.  The
     /// denomination is always units of the token to which this fractional fee is attached.
     struct FractionalFee {
-        bool netOfTransfers;
-
         // A rational number's numerator, used to set the amount of a value transfer to collect as a custom fee
-        int256 numerator;
+        int64 numerator;
 
         // A rational number's denominator, used to set the amount of a value transfer to collect as a custom fee
-        int256 denominator;
+        int64 denominator;
 
         // The minimum amount to assess
-        int256 minimumAmount;
+        int64 minimumAmount;
 
         // The maximum amount to assess (zero implies no maximum)
-        int256 maximumAmount;
+        int64 maximumAmount;
+        bool netOfTransfers;
 
         // The ID of the account to receive the custom fee, expressed as a solidity address
         address feeCollector;
@@ -192,30 +277,36 @@ interface IHederaTokenService {
     /// any fungible value, the ledger will assess the fallback fee, if present, to the new NFT owner.
     /// Royalty fees can only be added to tokens of type type NON_FUNGIBLE_UNIQUE.
     struct RoyaltyFee {
-        // The ID of the account to receive the custom fee, expressed as a solidity address
-        address feeCollector;
-
         // A fraction's numerator of fungible value exchanged for an NFT to collect as royalty
-        int256 numerator;
+        int64 numerator;
 
         // A fraction's denominator of fungible value exchanged for an NFT to collect as royalty
-        int256 denominator;
+        int64 denominator;
 
         // If present, the fee to assess to the NFT receiver when no fungible value
         // is exchanged with the sender. Consists of:
-        // useHbarsForPayment: Specifies this fee should be denominated in Hbar
         // amount: the amount to charge for the fee
         // tokenId: Specifies ID of token that should be used for fixed fee denomination
-        bool useHbarsForPayment;
-        int256 amount;
+        // useHbarsForPayment: Specifies this fee should be denominated in Hbar
+        int64 amount;
         address tokenId;
+        bool useHbarsForPayment;
+
+        // The ID of the account to receive the custom fee, expressed as a solidity address
+        address feeCollector;
     }
 
-    /// Query token info
-    /// @param token The token address to check
-    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    /// @return tokenInfo TokenInfo info for `token`
-    function getTokenInfo(address token) external returns (int64 responseCode, TokenInfo memory tokenInfo);
+    /**********************
+     * Direct HTS Calls   *
+     **********************/
+
+    /// Performs transfers among combinations of tokens and hbars
+    /// @param transferList the list of hbar transfers to do
+    /// @param tokenTransfers the list of token transfers to do
+    /// @custom:version 0.3.0 the signature of the previous version was cryptoTransfer(TokenTransferList[] memory tokenTransfers)
+    // function cryptoTransfer(TransferList memory transferList, TokenTransferList[] memory tokenTransfers)
+    //     external
+    //     returns (int64 responseCode);
 
     /// Mints an amount of the token to the defined treasury account
     /// @param token The token for which to mint tokens. If token does not exist, transaction results in
@@ -228,11 +319,17 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return newTotalSupply The new supply of tokens. For NFTs it is the total count of NFTs
     /// @return serialNumbers If the token is an NFT the newly generate serial numbers, othersise empty.
-    function mintToken(address token, int64 amount, bytes[] memory metadata) external returns (
-        int64 responseCode,
-        int64 newTotalSupply,
-        int64[] memory serialNumbers
-    );
+    function mintToken(
+        address token,
+        int64 amount,
+        bytes[] memory metadata
+    )
+        external
+        returns (
+            int64 responseCode,
+            int64 newTotalSupply,
+            int64[] memory serialNumbers
+        );
 
     /// Burns an amount of the token from the defined treasury account
     /// @param token The token for which to burn tokens. If token does not exist, transaction results in
@@ -243,8 +340,479 @@ interface IHederaTokenService {
     /// @param serialNumbers Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be burned.
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return newTotalSupply The new supply of tokens. For NFTs it is the total count of NFTs
-    function burnToken(address token, int64 amount, int64[] memory serialNumbers) external returns (
-        int64 responseCode,
-        int64 newTotalSupply
-    );
+    function burnToken(
+        address token,
+        int64 amount,
+        int64[] memory serialNumbers
+    ) external returns (int64 responseCode, int64 newTotalSupply);
+
+    ///  Associates the provided account with the provided tokens. Must be signed by the provided
+    ///  Account's key or called from the accounts contract key
+    ///  If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+    ///  If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+    ///  If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
+    ///  If any of the provided tokens has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+    ///  If an association between the provided account and any of the tokens already exists, the
+    ///  transaction will resolve to TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT.
+    ///  If the provided account's associations count exceed the constraint of maximum token associations
+    ///    per account, the transaction will resolve to TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED.
+    ///  On success, associations between the provided account and tokens are made and the account is
+    ///    ready to interact with the tokens.
+    /// @param account The account to be associated with the provided tokens
+    /// @param tokens The tokens to be associated with the provided account. In the case of NON_FUNGIBLE_UNIQUE
+    ///               Type, once an account is associated, it can hold any number of NFTs (serial numbers) of that
+    ///               token type
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function associateTokens(address account, address[] memory tokens)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Single-token variant of associateTokens. Will be mapped to a single entry array call of associateTokens
+    /// @param account The account to be associated with the provided token
+    /// @param token The token to be associated with the provided account
+    // function associateToken(address account, address token)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Dissociates the provided account with the provided tokens. Must be signed by the provided
+    /// Account's key.
+    /// If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+    /// If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+    /// If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
+    /// If any of the provided tokens has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+    /// If an association between the provided account and any of the tokens does not exist, the
+    /// transaction will resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+    /// If a token has not been deleted and has not expired, and the user has a nonzero balance, the
+    /// transaction will resolve to TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES.
+    /// If a <b>fungible token</b> has expired, the user can disassociate even if their token balance is
+    /// not zero.
+    /// If a <b>non fungible token</b> has expired, the user can <b>not</b> disassociate if their token
+    /// balance is not zero. The transaction will resolve to TRANSACTION_REQUIRED_ZERO_TOKEN_BALANCES.
+    /// On success, associations between the provided account and tokens are removed.
+    /// @param account The account to be dissociated from the provided tokens
+    /// @param tokens The tokens to be dissociated from the provided account.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function dissociateTokens(address account, address[] memory tokens)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Single-token variant of dissociateTokens. Will be mapped to a single entry array call of dissociateTokens
+    /// @param account The account to be associated with the provided token
+    /// @param token The token to be associated with the provided account
+    // function dissociateToken(address account, address token)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Creates a Fungible Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param initialTotalSupply Specifies the initial supply of tokens to be put in circulation. The
+    /// initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible.
+    /// @param decimals the number of decimal places a token is divisible by
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    // function createFungibleToken(
+    //     HederaToken memory token,
+    //     int64 initialTotalSupply,
+    //     int32 decimals
+    // ) external payable returns (int64 responseCode, address tokenAddress);
+
+    /// Creates a Fungible Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param initialTotalSupply Specifies the initial supply of tokens to be put in circulation. The
+    /// initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible.
+    /// @param decimals the number of decimal places a token is divisible by.
+    /// @param fixedFees list of fixed fees to apply to the token
+    /// @param fractionalFees list of fractional fees to apply to the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    // function createFungibleTokenWithCustomFees(
+    //     HederaToken memory token,
+    //     int64 initialTotalSupply,
+    //     int32 decimals,
+    //     FixedFee[] memory fixedFees,
+    //     FractionalFee[] memory fractionalFees
+    // ) external payable returns (int64 responseCode, address tokenAddress);
+
+    /// Creates an Non Fungible Unique Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    // function createNonFungibleToken(HederaToken memory token)
+    //     external
+    //     payable
+    //     returns (int64 responseCode, address tokenAddress);
+
+    /// Creates an Non Fungible Unique Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param fixedFees list of fixed fees to apply to the token
+    /// @param royaltyFees list of royalty fees to apply to the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    // function createNonFungibleTokenWithCustomFees(
+    //     HederaToken memory token,
+    //     FixedFee[] memory fixedFees,
+    //     RoyaltyFee[] memory royaltyFees
+    // ) external payable returns (int64 responseCode, address tokenAddress);
+
+    /**********************
+     * ABIV1 calls        *
+     **********************/
+
+    /// Initiates a Fungible Token Transfer
+    /// @param token The ID of the token as a solidity address
+    /// @param accountId account to do a transfer to/from
+    /// @param amount The amount from the accountId at the same index
+    // function transferTokens(
+    //     address token,
+    //     address[] memory accountId,
+    //     int64[] memory amount
+    // ) external returns (int64 responseCode);
+
+    /// Initiates a Non-Fungable Token Transfer
+    /// @param token The ID of the token as a solidity address
+    /// @param sender the sender of an nft
+    /// @param receiver the receiver of the nft sent by the same index at sender
+    /// @param serialNumber the serial number of the nft sent by the same index at sender
+    // function transferNFTs(
+    //     address token,
+    //     address[] memory sender,
+    //     address[] memory receiver,
+    //     int64[] memory serialNumber
+    // ) external returns (int64 responseCode);
+
+    /// Transfers tokens where the calling account/contract is implicitly the first entry in the token transfer list,
+    /// where the amount is the value needed to zero balance the transfers. Regular signing rules apply for sending
+    /// (positive amount) or receiving (negative amount)
+    /// @param token The token to transfer to/from
+    /// @param sender The sender for the transaction
+    /// @param recipient The receiver of the transaction
+    /// @param amount Non-negative value to send. a negative value will result in a failure.
+    // function transferToken(
+    //     address token,
+    //     address sender,
+    //     address recipient,
+    //     int64 amount
+    // ) external returns (int64 responseCode);
+
+    /// Transfers tokens where the calling account/contract is implicitly the first entry in the token transfer list,
+    /// where the amount is the value needed to zero balance the transfers. Regular signing rules apply for sending
+    /// (positive amount) or receiving (negative amount)
+    /// @param token The token to transfer to/from
+    /// @param sender The sender for the transaction
+    /// @param recipient The receiver of the transaction
+    /// @param serialNumber The serial number of the NFT to transfer.
+    // function transferNFT(
+    //     address token,
+    //     address sender,
+    //     address recipient,
+    //     int64 serialNumber
+    // ) external returns (int64 responseCode);
+
+    /// Allows spender to withdraw from your account multiple times, up to the value amount. If this function is called
+    /// again it overwrites the current allowance with value.
+    /// Only Applicable to Fungible Tokens
+    /// @param token The hedera token address to approve
+    /// @param spender the account address authorized to spend
+    /// @param amount the amount of tokens authorized to spend.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function approve(
+    //     address token,
+    //     address spender,
+    //     uint256 amount
+    // ) external returns (int64 responseCode);
+
+    /// Transfers `amount` tokens from `from` to `to` using the
+    //  allowance mechanism. `amount` is then deducted from the caller's allowance.
+    /// Only applicable to fungible tokens
+    /// @param token The address of the fungible Hedera token to transfer
+    /// @param from The account address of the owner of the token, on the behalf of which to transfer `amount` tokens
+    /// @param to The account address of the receiver of the `amount` tokens
+    /// @param amount The amount of tokens to transfer from `from` to `to`
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function transferFrom(address token, address from, address to, uint256 amount) external returns (int64 responseCode);
+
+    /// Returns the amount which spender is still allowed to withdraw from owner.
+    /// Only Applicable to Fungible Tokens
+    /// @param token The Hedera token address to check the allowance of
+    /// @param owner the owner of the tokens to be spent
+    /// @param spender the spender of the tokens
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return allowance The amount which spender is still allowed to withdraw from owner.
+    // function allowance(
+    //     address token,
+    //     address owner,
+    //     address spender
+    // ) external returns (int64 responseCode, uint256 allowance);
+
+    /// Allow or reaffirm the approved address to transfer an NFT the approved address does not own.
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to approve
+    /// @param approved The new approved NFT controller.  To revoke approvals pass in the zero address.
+    /// @param serialNumber The NFT serial number  to approve
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function approveNFT(
+    //     address token,
+    //     address approved,
+    //     uint256 serialNumber
+    // ) external returns (int64 responseCode);
+
+    /// Transfers `serialNumber` of `token` from `from` to `to` using the allowance mechanism.
+    /// Only applicable to NFT tokens
+    /// @param token The address of the non-fungible Hedera token to transfer
+    /// @param from The account address of the owner of `serialNumber` of `token`
+    /// @param to The account address of the receiver of `serialNumber`
+    /// @param serialNumber The NFT serial number to transfer
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function transferFromNFT(address token, address from, address to, uint256 serialNumber) external returns (int64 responseCode);
+
+    /// Get the approved address for a single NFT
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to check approval
+    /// @param serialNumber The NFT to find the approved address for
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return approved The approved address for this NFT, or the zero address if there is none
+    // function getApproved(address token, uint256 serialNumber)
+    //     external
+    //     returns (int64 responseCode, address approved);
+
+    /// Enable or disable approval for a third party ("operator") to manage
+    ///  all of `msg.sender`'s assets
+    /// @param token The Hedera NFT token address to approve
+    /// @param operator Address to add to the set of authorized operators
+    /// @param approved True if the operator is approved, false to revoke approval
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function setApprovalForAll(
+    //     address token,
+    //     address operator,
+    //     bool approved
+    // ) external returns (int64 responseCode);
+
+    /// Query if an address is an authorized operator for another address
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to approve
+    /// @param owner The address that owns the NFTs
+    /// @param operator The address that acts on behalf of the owner
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return approved True if `operator` is an approved operator for `owner`, false otherwise
+    // function isApprovedForAll(
+    //     address token,
+    //     address owner,
+    //     address operator
+    // ) external returns (int64 responseCode, bool approved);
+
+    /// Query if token account is frozen
+    /// @param token The token address to check
+    /// @param account The account address associated with the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return frozen True if `account` is frozen for `token`
+    // function isFrozen(address token, address account)
+    //     external
+    //     returns (int64 responseCode, bool frozen);
+
+    /// Query if token account has kyc granted
+    /// @param token The token address to check
+    /// @param account The account address associated with the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return kycGranted True if `account` has kyc granted for `token`
+    // function isKyc(address token, address account)
+    //     external
+    //     returns (int64 responseCode, bool kycGranted);
+
+    /// Operation to delete token
+    /// @param token The token address to be deleted
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function deleteToken(address token) external returns (int64 responseCode);
+
+    /// Query token custom fees
+    /// @param token The token address to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return fixedFees Set of fixed fees for `token`
+    /// @return fractionalFees Set of fractional fees for `token`
+    /// @return royaltyFees Set of royalty fees for `token`
+    // function getTokenCustomFees(address token)
+    //     external
+    //     returns (int64 responseCode, FixedFee[] memory fixedFees, FractionalFee[] memory fractionalFees, RoyaltyFee[] memory royaltyFees);
+
+    /// Query token default freeze status
+    /// @param token The token address to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return defaultFreezeStatus True if `token` default freeze status is frozen.
+    // function getTokenDefaultFreezeStatus(address token)
+    //     external
+    //     returns (int64 responseCode, bool defaultFreezeStatus);
+
+    /// Query token default kyc status
+    /// @param token The token address to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return defaultKycStatus True if `token` default kyc status is KycNotApplicable and false if Revoked.
+    // function getTokenDefaultKycStatus(address token)
+    //     external
+    //     returns (int64 responseCode, bool defaultKycStatus);
+
+    /// Query token expiry info
+    /// @param token The token address to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return expiry Expiry info for `token`
+    // function getTokenExpiryInfo(address token)
+    //     external
+    //     returns (int64 responseCode, Expiry memory expiry);
+
+    /// Query fungible token info
+    /// @param token The token address to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return fungibleTokenInfo FungibleTokenInfo info for `token`
+    // function getFungibleTokenInfo(address token)
+    //     external
+    //     returns (int64 responseCode, FungibleTokenInfo memory fungibleTokenInfo);
+
+    /// Query token info
+    /// @param token The token address to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenInfo TokenInfo info for `token`
+    function getTokenInfo(address token)
+        external
+        returns (int64 responseCode, TokenInfo memory tokenInfo);
+
+    /// Query token KeyValue
+    /// @param token The token address to check
+    /// @param keyType The keyType of the desired KeyValue
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return key KeyValue info for key of type `keyType`
+    // function getTokenKey(address token, uint keyType)
+    //     external
+    //     returns (int64 responseCode, KeyValue memory key);
+
+    /// Query non fungible token info
+    /// @param token The token address to check
+    /// @param serialNumber The NFT serialNumber to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return nonFungibleTokenInfo NonFungibleTokenInfo info for `token` `serialNumber`
+    // function getNonFungibleTokenInfo(address token, int64 serialNumber)
+    //     external
+    //     returns (int64 responseCode, NonFungibleTokenInfo memory nonFungibleTokenInfo);
+
+    /// Operation to freeze token account
+    /// @param token The token address
+    /// @param account The account address to be frozen
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function freezeToken(address token, address account)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Operation to unfreeze token account
+    /// @param token The token address
+    /// @param account The account address to be unfrozen
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function unfreezeToken(address token, address account)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Operation to grant kyc to token account
+    /// @param token The token address
+    /// @param account The account address to grant kyc
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function grantTokenKyc(address token, address account)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Operation to revoke kyc to token account
+    /// @param token The token address
+    /// @param account The account address to revoke kyc
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function revokeTokenKyc(address token, address account)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Operation to pause token
+    /// @param token The token address to be paused
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function pauseToken(address token) external returns (int64 responseCode);
+
+    /// Operation to unpause token
+    /// @param token The token address to be unpaused
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function unpauseToken(address token) external returns (int64 responseCode);
+
+    /// Operation to wipe fungible tokens from account
+    /// @param token The token address
+    /// @param account The account address to revoke kyc
+    /// @param amount The number of tokens to wipe
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function wipeTokenAccount(
+    //     address token,
+    //     address account,
+    //     int64 amount
+    // ) external returns (int64 responseCode);
+
+    /// Operation to wipe non fungible tokens from account
+    /// @param token The token address
+    /// @param account The account address to revoke kyc
+    /// @param  serialNumbers The serial numbers of token to wipe
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function wipeTokenAccountNFT(
+    //     address token,
+    //     address account,
+    //     int64[] memory serialNumbers
+    // ) external returns (int64 responseCode);
+
+    /// Operation to update token info
+    /// @param token The token address
+    /// @param tokenInfo The hedera token info to update token with
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function updateTokenInfo(address token, HederaToken memory tokenInfo)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Operation to update token expiry info
+    /// @param token The token address
+    /// @param expiryInfo The hedera token expiry info
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function updateTokenExpiryInfo(address token, Expiry memory expiryInfo)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Operation to update token expiry info
+    /// @param token The token address
+    /// @param keys The token keys
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function updateTokenKeys(address token, TokenKey[] memory keys)
+    //     external
+    //     returns (int64 responseCode);
+
+    /// Query if valid token found for the given address
+    /// @param token The token address
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return isToken True if valid token found for the given address
+    // function isToken(address token)
+    //     external returns
+    //     (int64 responseCode, bool isToken);
+
+    /// Query to return the token type for a given address
+    /// @param token The token address
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenType the token type. 0 is FUNGIBLE_COMMON, 1 is NON_FUNGIBLE_UNIQUE, -1 is UNRECOGNIZED
+    // function getTokenType(address token)
+    //     external returns
+    //     (int64 responseCode, int32 tokenType);
+
+    /// Initiates a Redirect For Token
+    /// @param token The token address
+    /// @param encodedFunctionSelector The function selector from the ERC20 interface + the bytes input for the function called
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return response The result of the call that had been encoded and sent for execution.
+    // function redirectForToken(address token, bytes memory encodedFunctionSelector) external returns (int64 responseCode, bytes memory response);
+
+    /// Update the custom fees for a fungible token
+    /// @param token The token address
+    /// @param fixedFees Set of fixed fees for `token`
+    /// @param fractionalFees Set of fractional fees for `token`
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function updateFungibleTokenCustomFees(address token,  IHederaTokenService.FixedFee[] memory fixedFees, IHederaTokenService.FractionalFee[] memory fractionalFees) external returns (int64 responseCode);
+
+    /// Update the custom fees for a non-fungible token
+    /// @param token The token address
+    /// @param fixedFees Set of fixed fees for `token`
+    /// @param royaltyFees Set of royalty fees for `token`
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    // function updateNonFungibleTokenCustomFees(address token, IHederaTokenService.FixedFee[] memory fixedFees, IHederaTokenService.RoyaltyFee[] memory royaltyFees) external returns (int64 responseCode);
 }

--- a/contracts/StrStore.sol
+++ b/contracts/StrStore.sol
@@ -49,14 +49,55 @@ function storeInt(address target, uint256 slot, int256 value) {
     storeBytes32(target, slot, intData);
 }
 
+function storeInt64(address target, uint256 slot, int64 value) {
+    bytes32 data = bytes32(abi.encodePacked(value));
+    storeBytes32(target, slot, data);
+}
+
+function storeInt64(address target, uint256 slot, uint8 offset, int64 value) {
+    require(offset + 8 <= 32, "int64: offset out of range");
+
+    bytes32 mask = bytes32(uint256(~uint64(0))) << (offset * 8);
+    bytes32 slotData = vm.load(target, bytes32(slot)) & ~mask;
+    bytes32 data = bytes32(uint256(uint64(value)));
+    data = data << (offset * 8);
+    data = slotData | data;
+    
+    storeBytes32(target, slot, data);
+}
+
 function storeBool(address target, uint256 slot, bool value) {
     bytes32 boolData = value ? bytes32(uint256(1)) : bytes32(uint256(0));
     storeBytes32(target, slot, boolData);
 }
 
+function storeBool(address target, uint256 slot, uint8 offset, bool value) {
+    require(offset + 1 <= 32, "bool: offset out of range");
+
+    bytes32 mask = bytes32(uint256(~uint8(0))) << (offset * 8);
+    bytes32 slotData = vm.load(target, bytes32(slot)) & ~mask;
+    bytes32 data = bytes32(uint256(value ? 1 : 0));
+    data = data << (offset * 8);
+    data = slotData | data;
+
+    storeBytes32(target, slot, data);
+}
+
 function storeAddress(address target, uint256 slot, address value) {
-    bytes32 addressData = bytes32(uint256(uint160(value)));
-    storeBytes32(target, slot, addressData);
+    bytes32 data = bytes32(uint256(uint160(value)));
+    storeBytes32(target, slot, data);
+}
+
+function storeAddress(address target, uint256 slot, uint8 offset, address value) {
+    require(offset + 20 <= 32, "address: offset out of range");
+
+    bytes32 mask = bytes32(uint256(~uint160(0))) << (offset * 8);
+    bytes32 slotData = vm.load(target, bytes32(slot)) & ~mask;
+    bytes32 data = bytes32(uint256(uint160(value)));
+    data = data << (offset * 8);
+    data = slotData | data;
+    
+    storeBytes32(target, slot, data);
 }
 
 function storeBytes32(address target, uint256 slot, bytes32 value) {

--- a/contracts/StrStore.sol
+++ b/contracts/StrStore.sol
@@ -44,11 +44,6 @@ function storeUint(address target, uint256 slot, uint256 value) {
     storeBytes32(target, slot, uintData);
 }
 
-function storeInt(address target, uint256 slot, int256 value) {
-    bytes32 intData = bytes32(abi.encodePacked(value));
-    storeBytes32(target, slot, intData);
-}
-
 function storeInt64(address target, uint256 slot, int64 value) {
     bytes32 data = bytes32(abi.encodePacked(value));
     storeBytes32(target, slot, data);

--- a/src/slotmap.js
+++ b/src/slotmap.js
@@ -84,6 +84,8 @@ class SlotMap {
 }
 
 /**
+ * Packs values into a single slot shifting according to their offsets.
+ *
  * @param {{offset: number, value: string}[]} values
  * @returns {string}
  */
@@ -133,7 +135,6 @@ const _types = {
     },
     t_uint8: val => [toIntHex256(val)],
     t_uint256: val => [toIntHex256(val)],
-    t_int256: str => [toIntHex256(str ?? 0)],
     t_int64: str => [toIntHex256(str ?? 0)],
     t_address: str => [
         str

--- a/test/StrStore.t.sol
+++ b/test/StrStore.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test, console} from "forge-std/Test.sol";
-import {storeString, storeBytes, storeUint, storeInt, storeInt64, storeBool, storeAddress, storeBytes32} from "../contracts/StrStore.sol";
+import {storeString, storeBytes, storeUint, storeInt64, storeBool, storeAddress, storeBytes32} from "../contracts/StrStore.sol";
 
 contract StrStoreTest is Test {
 
@@ -19,14 +19,14 @@ contract StrStoreTest is Test {
         storeString(address(_c), 2, value);
         assertEq(_c.symbol(), value);
 
-        assertEq(_c.gap(), 0);
+        assertEq(_c.gap1(), 0);
     }
 
     function storeBytesTest(bytes memory value) private {
         storeBytes(address(_c), 3, value);
         assertEq(_c.someBytes(), value);
 
-        assertEq(_c.someInt(), 0);
+        assertEq(_c.gap2(), 0);
 
         storeBytes(address(_c), 5, value);
         assertEq(_c.someOtherBytes(), value);
@@ -34,19 +34,9 @@ contract StrStoreTest is Test {
 
     function storeUintTest(uint256 value) private {
         storeUint(address(_c), 1, value);
-        assertEq(_c.gap(), value);
+        assertEq(_c.gap1(), value);
         assertEq(_c.name(), "");
         assertEq(_c.symbol(), "");
-    }
-
-    function storeIntTest(int256 value) private {
-        storeInt(address(_c), 4, value);
-        assertEq(_c.someInt(), value);
-        assertEq(_c.someBytes(), new bytes(0));
-        assertEq(_c.someOtherBytes(), new bytes(0));
-
-        storeInt(address(_c), 9, value);
-        assertEq(_c.someOtherInt(), value);
     }
 
     function storeBoolTest(bool value) private {
@@ -59,7 +49,7 @@ contract StrStoreTest is Test {
     function storeAddressTest(address value) private {
         storeAddress(address(_c), 8, value);
         assertEq(_c.someAddress(), value);
-        assertEq(_c.someOtherInt(), 0);
+        assertEq(_c.gap3(), 0);
         assertEq(_c.someBytes32(), bytes32(0));
     }
 
@@ -122,20 +112,6 @@ contract StrStoreTest is Test {
 
     function test_store_uint_max() external {
         storeUintTest(type(uint256).max);
-    }
-
-    // Integers
-
-    function test_store_int_zero() external {
-        storeIntTest(0);
-    }
-
-    function test_store_int_max() external {
-        storeIntTest(type(int256).max);
-    }
-
-    function test_store_int_min() external {
-        storeIntTest(type(int256).min);
     }
 
     // Booleans
@@ -232,15 +208,15 @@ struct Slot {
 
 contract C {
     string public name;
-    uint256 public gap;
+    uint256 public gap1;
     string public symbol;
     bytes public someBytes;
-    int256 public someInt;
+    uint256 public gap2;
     bytes public someOtherBytes;
     bool public someBool;
     bytes32 public someBytes32;
     address public someAddress;
-    int256 public someOtherInt;
+    uint256 public gap3;
 
     bool public offsetBool1;
     function offsetBool1Slot() external pure returns (Slot memory) {

--- a/test/slotMapOf.test.js
+++ b/test/slotMapOf.test.js
@@ -18,29 +18,69 @@
 
 const { expect } = require('chai');
 
-const { slotMapOf } = require('../src/slotmap');
+const { slotMapOf, packValues } = require('../src/slotmap');
+const { toIntHex256 } = require('../src/utils');
 
 const mirrorNode =
     /** @type{Pick<import('@hashgraph/system-contracts-forking').IMirrorNodeClient, 'getAccount'>} */ ({
         getAccount: async address => ({ account: '', evm_address: address?.replace('0.0.', '') }),
     });
 
-describe('::slotMapOf', function () {
-    ['MFCT', 'USDC'].forEach(symbol => {
-        describe(symbol, function () {
-            const map = slotMapOf(require(`../test/data/${symbol}/getToken.json`));
+describe('::slotmap', function () {
+    describe('slotMapOf', function () {
+        ['MFCT', 'USDC'].forEach(symbol => {
+            describe(symbol, function () {
+                it(`should have valid slot fields`, async function () {
+                    const map = slotMapOf(require(`../test/data/${symbol}/getToken.json`));
 
-            [...map._map.entries()].forEach(([slot, { value, path }]) => {
-                it(`should have valid slot \`${slot}\` for field \`${path}\``, async function () {
-                    expect(slot).to.be.not.undefined;
-                    expect(value).to.be.not.undefined;
-                    if (typeof value === 'function') {
-                        value = await value(mirrorNode, 0);
-                    }
-                    expect(value).to.be.a('string');
-                    expect(value).to.be.have.length(64);
-                    expect(() => BigInt(`0x${value}`)).to.not.throw(SyntaxError);
+                    [...map._map.entries()].forEach(([slot, values]) => {
+                        expect(slot).to.be.not.undefined;
+                        expect(values).to.be.not.undefined;
+                        expect(values.length).to.be.greaterThan(0);
+
+                        values.forEach(async ({ value }) => {
+                            if (typeof value === 'function') {
+                                value = await value(mirrorNode, 0);
+                            }
+                            expect(values).to.be.a('string');
+                            expect(value).to.be.have.length(64);
+                            expect(() => BigInt(`0x${value}`)).to.not.throw(SyntaxError);
+                        });
+                    });
                 });
+            });
+        });
+    });
+
+    describe('packValues', function () {
+        it('should not accept empty values', function () {
+            expect(() => packValues([])).to.throw('values must not be empty');
+        });
+
+        [
+            {
+                values: [{ offset: 0, value: '1234' }],
+                result: 0x1234n,
+            },
+            {
+                values: [
+                    { offset: 0, value: '12' },
+                    { offset: 1, value: '34' },
+                    { offset: 2, value: '45' },
+                ],
+                result: 0x45_34_12n,
+            },
+            {
+                values: [
+                    { offset: 0, value: '1234567890abcdef' },
+                    { offset: 8, value: '01' },
+                    { offset: 9, value: '12345678' },
+                ],
+                result: 0x12345678_01_1234567890abcdefn,
+            },
+        ].forEach(({ values, result }) => {
+            it(`should pack ${JSON.stringify(values)} into 0x${result.toString(16)}`, function () {
+                expect(packValues(values)).to.be.equal(toIntHex256(result));
             });
         });
     });

--- a/test/storageLayout.test.js
+++ b/test/storageLayout.test.js
@@ -43,14 +43,5 @@ describe('::storageLayout', function () {
             const encodings = new Set(Object.values(types).map(({ encoding }) => encoding));
             expect([...encodings]).to.be.have.members(['inplace', 'bytes', 'dynamic_array']);
         });
-
-        it('should have all its struct members with offset `0` to avoid field packing', function () {
-            Object.values(types)
-                .filter(ty => 'members' in ty)
-                .flatMap(ty => ty.members)
-                .forEach(member => {
-                    expect(member.offset).to.be.equal(0, member.label);
-                });
-        });
     });
 });


### PR DESCRIPTION
**Description**:

This PR includes support to deal with field offsets defined in the storage layout. It restores the original field definitions from `IHederaTokenService` so both HTS real and emulated are compatible.

In addition, it includes (commented out) all methods left to implement. This is to measure how much have we covered yet from HTS.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #159.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Foundry's implementation is based on @victor-yanev early implementation of offsets.

For Hardhat, given all slots for token metadata are fetched at the same time, there is not need to mask previous values.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
