### PR TITLE
feat: allowance supported in nft

### DIFF
--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -473,7 +473,8 @@ contract HtsSystemContractJson is HtsSystemContract {
     function _isApprovedForAllSlot(address owner, address operator) internal override virtual returns (bytes32) {
         bytes32 slot = super._isApprovedForAllSlot(owner, operator);
         if (vm.load(_scratchAddr(), slot) == bytes32(0)) {
-            // TODO: Implement this
+            bool approved = mirrorNode().isApprovedForAll(address(this), owner, operator);
+            _setValue(slot, bytes32(uint256(approved ? 1 : 0)));
         }
         return slot;
     }

--- a/contracts/MirrorNode.sol
+++ b/contracts/MirrorNode.sol
@@ -24,6 +24,8 @@ abstract contract MirrorNode {
 
     function fetchAllowance(address token, uint32 ownerNum, uint32 spenderNum) external virtual returns (string memory json);
 
+    function fetchNftAllowance(address token, uint32 ownerNum, uint32 operatorNum) external virtual returns (string memory json);
+
     function fetchAccount(string memory account) external virtual returns (string memory json);
 
     function fetchTokenRelationshipOfAccount(string memory account, address token) external virtual returns (string memory json);
@@ -54,6 +56,16 @@ abstract contract MirrorNode {
             return getAccountAddress(spender);
         }
         return address(0);
+    }
+
+    function isApprovedForAll(address token, address owner, address operator) external returns (bool) {
+        uint32 ownerNum = _getAccountNum(owner);
+        if (ownerNum == 0) return false;
+        uint32 operatorNum = _getAccountNum(operator);
+        if (operatorNum == 0) return false;
+        string memory json = this.fetchNftAllowance(token, ownerNum, operatorNum);
+        return vm.keyExistsJson(json, ".allowances[0].approved_for_all")
+            && vm.parseJsonBool(json, ".allowances[0].approved_for_all");
     }
 
     function getBalance(address token, address account) external returns (uint256) {

--- a/contracts/MirrorNodeFFI.sol
+++ b/contracts/MirrorNodeFFI.sol
@@ -52,6 +52,17 @@ contract MirrorNodeFFI is MirrorNode {
         ));
     }
 
+    function fetchNftAllowance(address token, uint32 ownerNum, uint32 operatorNum) isValid(token) external override returns (string memory) {
+        return _get(string.concat(
+            "accounts/0.0.",
+            vm.toString(ownerNum),
+            "/allowances/nfts?token.id=0.0.",
+            vm.toString(uint160(token)),
+            "&account.id=0.0.",
+            vm.toString(operatorNum)
+        ));
+    }
+
     function fetchAccount(string memory idOrAliasOrEvmAddress) external override returns (string memory) {
         return _get(string.concat(
             "accounts/",

--- a/test/ERC721.t.sol
+++ b/test/ERC721.t.sol
@@ -57,7 +57,7 @@ contract ERC721TokenTest is Test, TestSetup, IERC721Events, IERC20Events {
     }
 
     function test_ERC721_setApprovalForAll() external {
-        address operator = makeAddr("operator");
+        address operator = CFNFTFF_ALLOWED_SPENDER;
         vm.prank(CFNFTFF_TREASURY);
         vm.expectEmit(CFNFTFF);
         emit ApprovalForAll(CFNFTFF_TREASURY, operator, true);
@@ -71,8 +71,7 @@ contract ERC721TokenTest is Test, TestSetup, IERC721Events, IERC20Events {
     }
 
     function test_ERC721_isApprovedForAll() external {
-        address operator = makeAddr("operator");
-        assertFalse(IERC721(CFNFTFF).isApprovedForAll(CFNFTFF_TREASURY, operator));
+        assertFalse(IERC721(CFNFTFF).isApprovedForAll(CFNFTFF_TREASURY, CFNFTFF_ALLOWED_SPENDER));
     }
 
     function test_ERC721_tokenURI_shorter_than_31_bytes() external view {

--- a/test/data/CFNFTFF/getAllowanceForToken_0.0.4436613_0.0.2.json
+++ b/test/data/CFNFTFF/getAllowanceForToken_0.0.4436613_0.0.2.json
@@ -1,0 +1,6 @@
+{
+    "allowances": [],
+    "links": {
+        "next": null
+    }
+}

--- a/test/data/CFNFTFF/getAllowanceForToken_0.0.4436613_0.0.4454450.json
+++ b/test/data/CFNFTFF/getAllowanceForToken_0.0.4436613_0.0.4454450.json
@@ -1,0 +1,19 @@
+{
+    "allowances": [
+        {
+            "approved_for_all": false,
+            "amount": 5000000,
+            "amount_granted": 5000000,
+            "owner": "0.0.4436613",
+            "spender": "0.0.4454450",
+            "timestamp": {
+                "from": "1714151124.613750003",
+                "to": null
+            },
+            "token_id": "0.0.5308378"
+        }
+    ],
+    "links": {
+        "next": null
+    }
+}

--- a/test/data/getAccount_0x006217c47ffa5eb3f3c92247fffe22ad998242c5.json
+++ b/test/data/getAccount_0x006217c47ffa5eb3f3c92247fffe22ad998242c5.json
@@ -1,0 +1,29 @@
+{
+    "account": "0.0.2",
+    "alias": "HIQQEQVXYO7OUKXW37GIOTCB2EZSIY2APYUD6YBM5DXSZPRSJARVMG3P",
+    "auto_renew_period": 7776000,
+    "balance": {
+        "balance": 94073993575,
+        "timestamp": "1734948283.696029000",
+        "tokens": []
+    },
+    "created_timestamp": "1718132880.546033646",
+    "decline_reward": false,
+    "deleted": false,
+    "ethereum_nonce": 42,
+    "evm_address": "0x435d7d41d4f69f958bda7a8d9f549a0dd9b64c86",
+    "expiry_timestamp": "1725908880.546033646",
+    "key": {
+        "_type": "ECDSA_SECP256K1",
+        "key": "0242b7c3beea2af6dfcc874c41d1332463407e283f602ce8ef2cbe324823561b6f"
+    },
+    "max_automatic_token_associations": 0,
+    "memo": "auto-created account",
+    "pending_reward": 0,
+    "receiver_sig_required": false,
+    "staked_account_id": null,
+    "staked_node_id": null,
+    "stake_period_start": null,
+    "transactions": [],
+    "links": {}
+}

--- a/test/lib/MirrorNodeMock.sol
+++ b/test/lib/MirrorNodeMock.sol
@@ -39,6 +39,14 @@ contract MirrorNodeMock is MirrorNode {
         return vm.readFile(path);
     }
 
+    function fetchNftAllowance(address token, uint32 ownerNum, uint32 operatorNum) isValid(token) external override view returns (string memory) {
+        string memory symbol = _symbolOf[token];
+        string memory ownerId = vm.toString(ownerNum);
+        string memory operatorId = vm.toString(operatorNum);
+        string memory path = string.concat("./test/data/", symbol, "/getAllowanceForToken_0.0.", ownerId, "_0.0.", operatorId, ".json");
+        return vm.readFile(path);
+    }
+
     function fetchAccount(string memory account) external override view returns (string memory) {
         string memory path = string.concat("./test/data/getAccount_", vm.toLowercase(account), ".json");
         return vm.readFile(path);


### PR DESCRIPTION
**Description**:
I've added support for "Allowance for All" functionality for NFTs. I decided to create a separate PR for this feature because I'm uncertain whether the allowances/nft method can be used already. Based on my tests, it seems that it may not currently work correctly on mirronode. Perhaps that is why it is not even included in the documentation:
https://docs.hedera.com/hedera/sdks-and-apis/rest-api

I'd appreciate any feedback or insights on this issue.


**Related issue(s)**:

Fixes #125

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
