### PR TITLE
feat: [Hardhat] implement nft support for the json rpc api library and js mock …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,8 +201,7 @@ jobs:
         run: node test/scripts/json-rpc-mock.js &
 
       - name: Run Forge tests using JSON-RPC mock server for storage emulation (with forking)
-        # Remove no-match-contract when the support for ERC721 is implemented in the JSON RPC mock server (#80 task)
-        run: forge test -vvv --fork-url http://localhost:7546 --no-storage-caching --no-match-contract ^ERC721TokenTest$
+        run: forge test -vvv --fork-url http://localhost:7546 --no-storage-caching
 
   foundry-example-tests:
     name: 'Foundry example tests w/mainnet'

--- a/src/forwarder/mirror-node-client.js
+++ b/src/forwarder/mirror-node-client.js
@@ -61,6 +61,19 @@ class MirrorNodeClient {
     }
 
     /**
+     * Fetches information about an NFT by its token ID and serial ID.
+     *
+     * @param {string} tokenId the token ID to fetch.
+     * @param {number} serialId the serial ID of the NFT to fetch.
+     * @param {number} blockNumber
+     * @returns {Promise<Record<string, unknown> | null>} a `Promise` resolving to the token information or null if not found.
+     */
+    async getNftByTokenIdAndNumber(tokenId, serialId, blockNumber) {
+        const timestamp = await this.getBlockQueryParam(blockNumber);
+        return this._get(`tokens/${tokenId}/nft/${serialId}?${timestamp}`);
+    }
+
+    /**
      * Get token relationship for an account.
      *
      * @param {string} idOrAliasOrEvmAddress The ID or alias or EVM address of the account
@@ -96,6 +109,20 @@ class MirrorNodeClient {
     getAllowanceForToken(accountId, tokenId, spenderId) {
         return this._get(
             `accounts/${accountId}/allowances/tokens?token.id=${tokenId}&spender.id=${spenderId}`
+        );
+    }
+
+    /**
+     * Fetches token allowances for a specific account, token, and operator.
+     *
+     * @param {string} accountId The owner's account ID.
+     * @param {string} tokenId The token ID.
+     * @param {string} operatorId The operator's account ID.
+     * @returns {Promise<{ allowances: { approved_for_all: boolean }[] } | null>} A `Promise` resolving to the approval.
+     */
+    getAllowanceForNFT(accountId, tokenId, operatorId) {
+        return this._get(
+            `accounts/${accountId}/allowances/nfts?token.id=${tokenId}&account.id=${operatorId}`
         );
     }
 

--- a/src/forwarder/mirror-node-client.js
+++ b/src/forwarder/mirror-node-client.js
@@ -68,7 +68,7 @@ class MirrorNodeClient {
      * @param {number} blockNumber
      * @returns {Promise<Record<string, unknown> | null>} a `Promise` resolving to the token information or null if not found.
      */
-    async getNftByTokenIdAndNumber(tokenId, serialId, blockNumber) {
+    async getNftByTokenIdAndSerial(tokenId, serialId, blockNumber) {
         const timestamp = await this.getBlockQueryParam(blockNumber);
         return this._get(`tokens/${tokenId}/nft/${serialId}?${timestamp}`);
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,7 +43,7 @@ interface IMirrorNodeClient {
      * @param serialId The serial id of the NFT.
      * @param blockNumber
      */
-    getNftByTokenIdAndNumber(
+    getNftByTokenIdAndSerial(
         tokenId: string,
         serialId: number,
         blockNumber: number

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,6 +33,23 @@ interface IMirrorNodeClient {
     getTokenById(tokenId: string, blockNumber: number): Promise<Record<string, unknown> | null>;
 
     /**
+     * Get NFT by token id and serial id.
+     *
+     * Returns token NFT entity information given the token id and serial id.
+     *
+     * This method should call the Mirror Node API endpoint `GET /api/v1/tokens/{tokenId}/nft/{serialId}`.
+     *
+     * @param tokenId The ID of the token to return information for.
+     * @param serialId The serial id of the NFT.
+     * @param blockNumber
+     */
+    getNftByTokenIdAndNumber(
+        tokenId: string,
+        serialId: number,
+        blockNumber: number
+    ): Promise<Record<string, unknown> | null>;
+
+    /**
      * Get token relationship for an account.
      *
      * This method should call the Mirror Node API endpoint: `GET /api/v1/accounts/{idOrAliasOrEvmAddress}/tokens`.
@@ -88,6 +105,26 @@ interface IMirrorNodeClient {
     ): Promise<{
         allowances: {
             amount: number;
+        }[];
+    } | null>;
+
+    /**
+     * Returns information for non-fungible token allowances for an account.
+     *
+     * NOTE: `blockNumber` is not yet included until we fix issue
+     * https://github.com/hashgraph/hedera-forking/issues/89.
+     *
+     * @param accountId Account alias or account id or evm address.
+     * @param tokenId The ID of the token to return information for.
+     * @param operatorId The ID of the operator to return information for.
+     */
+    getAllowanceForNFT(
+        accountId: string,
+        tokenId: string,
+        operatorId: string
+    ): Promise<{
+        allowances: {
+            approved_for_all: boolean;
         }[];
     } | null>;
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const { strict: assert } = require('assert');
 const debug = require('util').debuglog('hts-forking');
 
 const { ZERO_HEX_32_BYTE, toIntHex256 } = require('./utils');
-const { slotMapOf, packValues } = require('./slotmap');
+const { slotMapOf, packValues, persistentSlotMapOf } = require('./slotmap');
 const { deployedBytecode } = require('../out/HtsSystemContract.sol/HtsSystemContract.json');
 
 const HTSAddress = '0x0000000000000000000000000000000000000167';
@@ -138,11 +138,118 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
         return ret(ZERO_HEX_32_BYTE, `Token ${tokenId} not associated with ${accountId}`);
     }
 
-    const token = await mirrorNodeClient.getTokenById(tokenId, blockNumber);
-    if (token === null) return ret(ZERO_HEX_32_BYTE, `Token \`${tokenId}\` not found`);
-    const unresolvedValues = slotMapOf(token).load(nrequestedSlot);
-    if (unresolvedValues === undefined)
-        return ret(ZERO_HEX_32_BYTE, `Requested slot does not match any field slots`);
+    // Encoded `address(tokenId).getApproved(serialId)` slot
+    // slot(256) = `getApproved`selector(32) + padding(192) + serialId(32)
+    if (
+        nrequestedSlot >> 32n ===
+        0x81812fc_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
+    ) {
+        const serialId = parseInt(requestedSlot.slice(-8), 16);
+        const { spender } =
+            (await mirrorNodeClient.getNftByTokenIdAndNumber(tokenId, serialId, blockNumber)) ?? {};
+        if (typeof spender !== 'string')
+            return ret(
+                ZERO_HEX_32_BYTE,
+                `NFT ${tokenId}#${serialId} is not approved to any address`
+            );
+        const account = await mirrorNodeClient.getAccount(spender, blockNumber);
+        if (account === null)
+            return ret(
+                ZERO_HEX_32_BYTE,
+                `NFT ${tokenId}#${serialId} is approved to address \`${spender}\`, failed to get its EVM Alias`
+            );
+
+        return ret(
+            account.evm_address,
+            `NFT ${tokenId}#${serialId} is approved to ${account.evm_address}`
+        );
+    }
+
+    // Encoded `address(tokenId).ownerOf(serialId)` slot
+    // slot(256) = `ownerOf`selector(32) + padding(192) + serialId(32)
+    if (
+        nrequestedSlot >> 32n ===
+        0x6352211e_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
+    ) {
+        const serialId = parseInt(requestedSlot.slice(-8), 16);
+        const nft = (await mirrorNodeClient.getNftByTokenIdAndNumber(
+            tokenId,
+            serialId,
+            blockNumber
+        )) ?? {
+            account_id: null,
+        };
+        if (typeof nft['account_id'] !== 'string')
+            return ret(
+                ZERO_HEX_32_BYTE,
+                `Failed to determine an owner of the NFT ${tokenId}#${serialId}`
+            );
+        const account = await mirrorNodeClient.getAccount(`${nft['account_id']}`, blockNumber);
+        if (account === null)
+            return ret(
+                ZERO_HEX_32_BYTE,
+                `NFT ${tokenId}#${serialId} belongs to \`${nft['account_id']}\`, failed to get its EVM Alias`
+            );
+
+        return ret(
+            account.evm_address,
+            `NFT ${tokenId}#${serialId} is approved to ${account.evm_address}`
+        );
+    }
+
+    // Encoded `address(tokenId).isApprovedForAll(owner, operator)` slot
+    // slot(256) = `isApprovedForAll`selector(32) + padding(160) + ownerId(32) + operatorId(32)
+    if (nrequestedSlot >> 64n === 0xe985e9c5_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n) {
+        const operatorId = `0.0.${parseInt(requestedSlot.slice(-8), 16)}`;
+        const ownerId = `0.0.${parseInt(requestedSlot.slice(-16, -8), 16)}`;
+        const { allowances } = (await mirrorNodeClient.getAllowanceForNFT(
+            ownerId,
+            tokenId,
+            operatorId
+        )) ?? { allowances: [] };
+
+        if (allowances.length === 0)
+            return ret(
+                ZERO_HEX_32_BYTE,
+                `${tokenId}.isApprovedForAll(${ownerId},${operatorId}) not found`
+            );
+        const value = allowances[0].approved_for_all ? 1 : 0;
+        return ret(
+            `0x${value.toString(16).padStart(64, '0')}`,
+            `Requested slot matches ${tokenId}.isApprovedForAll(${ownerId},${operatorId})`
+        );
+    }
+
+    // Encoded `address(tokenId).tokenURI(serialId)` slot
+    // slot(256) = `tokenURI`selector(32) + padding(192) + serialId(32)
+    if (
+        nrequestedSlot >> 32n ===
+        0xc87b56dd_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
+    ) {
+        const serialId = parseInt(requestedSlot.slice(-8), 16);
+        const { metadata } = (await mirrorNodeClient.getNftByTokenIdAndNumber(
+            tokenId,
+            serialId,
+            blockNumber
+        )) ?? {
+            metadata: null,
+        };
+        if (typeof metadata !== 'string')
+            return ret(
+                ZERO_HEX_32_BYTE,
+                `Failed to get the metadata of the NFT ${tokenId}#${serialId}`
+            );
+        persistentSlotMapOf(tokenId).store(nrequestedSlot, atob(metadata));
+    }
+    let unresolvedValues = persistentSlotMapOf(tokenId).load(nrequestedSlot);
+    if (unresolvedValues === undefined) {
+        const token = await mirrorNodeClient.getTokenById(tokenId, blockNumber);
+        if (token === null) return ret(ZERO_HEX_32_BYTE, `Token \`${tokenId}\` not found`);
+        unresolvedValues = slotMapOf(token).load(nrequestedSlot);
+
+        if (unresolvedValues === undefined)
+            return ret(ZERO_HEX_32_BYTE, `Requested slot does not match any field slots`);
+    }
     const values = await Promise.all(
         unresolvedValues.map(async ({ offset, path, value }) => ({
             offset,

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
     ) {
         const serialId = parseInt(requestedSlot.slice(-8), 16);
         const { spender } =
-            (await mirrorNodeClient.getNftByTokenIdAndNumber(tokenId, serialId, blockNumber)) ?? {};
+            (await mirrorNodeClient.getNftByTokenIdAndSerial(tokenId, serialId, blockNumber)) ?? {};
         if (typeof spender !== 'string')
             return ret(
                 ZERO_HEX_32_BYTE,
@@ -172,7 +172,7 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
         0x6352211e_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
     ) {
         const serialId = parseInt(requestedSlot.slice(-8), 16);
-        const nft = (await mirrorNodeClient.getNftByTokenIdAndNumber(
+        const nft = (await mirrorNodeClient.getNftByTokenIdAndSerial(
             tokenId,
             serialId,
             blockNumber
@@ -227,7 +227,7 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
         0xc87b56dd_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
     ) {
         const serialId = parseInt(requestedSlot.slice(-8), 16);
-        const { metadata } = (await mirrorNodeClient.getNftByTokenIdAndNumber(
+        const { metadata } = (await mirrorNodeClient.getNftByTokenIdAndSerial(
             tokenId,
             serialId,
             blockNumber

--- a/test/getHtsStorageAt.test.js
+++ b/test/getHtsStorageAt.test.js
@@ -48,7 +48,7 @@ describe('::getHtsStorageAt', function () {
         async getTokenRelationship(_idOrAliasOrEvmAddress, _tokenId) {
             throw Error('Not implemented');
         },
-        async getNftByTokenIdAndNumber(_tokenId, _serialId) {
+        async getNftByTokenIdAndSerial(_tokenId, _serialId) {
             throw Error('Not implemented');
         },
         async getAccount(_idOrAliasOrEvmAddress) {
@@ -408,7 +408,7 @@ describe('::getHtsStorageAt', function () {
                         /** @type {IMirrorNodeClient} */
                         const mirrorNodeClient = {
                             ...mirrorNodeClientStub,
-                            getNftByTokenIdAndNumber(tokenId, _serial) {
+                            getNftByTokenIdAndSerial(tokenId, _serial) {
                                 // https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.4271533/nfts/1
                                 expect(tokenId).to.be.equal(
                                     nftResult.token_id,
@@ -441,7 +441,7 @@ describe('::getHtsStorageAt', function () {
                         /** @type {IMirrorNodeClient} */
                         const mirrorNodeClient = {
                             ...mirrorNodeClientStub,
-                            getNftByTokenIdAndNumber(tokenId, _serial) {
+                            getNftByTokenIdAndSerial(tokenId, _serial) {
                                 // https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.4271533/nfts/1
                                 expect(tokenId).to.be.equal(
                                     nftResult.token_id,
@@ -474,7 +474,7 @@ describe('::getHtsStorageAt', function () {
                         /** @type {IMirrorNodeClient} */
                         const mirrorNodeClient = {
                             ...mirrorNodeClientStub,
-                            getNftByTokenIdAndNumber(tokenId, _serial) {
+                            getNftByTokenIdAndSerial(tokenId, _serial) {
                                 // https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.4271533/nfts/1
                                 expect(tokenId).to.be.equal(
                                     nftResult.token_id,

--- a/test/getHtsStorageAt.test.js
+++ b/test/getHtsStorageAt.test.js
@@ -48,6 +48,9 @@ describe('::getHtsStorageAt', function () {
         async getTokenRelationship(_idOrAliasOrEvmAddress, _tokenId) {
             throw Error('Not implemented');
         },
+        async getNftByTokenIdAndNumber(_tokenId, _serialId) {
+            throw Error('Not implemented');
+        },
         async getAccount(_idOrAliasOrEvmAddress) {
             throw Error('Not implemented');
         },
@@ -55,6 +58,9 @@ describe('::getHtsStorageAt', function () {
             throw Error('Not implemented');
         },
         async getAllowanceForToken(_accountId, _tokenId, _spenderId) {
+            throw Error('Not implemented');
+        },
+        async getAllowanceForNFT(_accountId, _tokenId, _operatorId) {
             throw Error('Not implemented');
         },
     };
@@ -161,9 +167,54 @@ describe('::getHtsStorageAt', function () {
             expect(result).to.be.equal(`0x${'58d'.padStart(64, '0')}`);
         });
     });
+    /**
+     * Pads `accountId` to be encoded within a storage slot.
+     *
+     * @param {number} accountId The `accountId` to pad.
+     * @returns {string}
+     */
+    const padAccountId = accountId => accountId.toString(16).padStart(8, '0');
+
+    /**
+     * Pads `accountId` to be encoded within a storage slot.
+     *
+     * @param {string|null} result Response returned by eth_getStorageAt
+     * @param {string} expectedString Expected string.
+     * @param {IMirrorNodeClient} client Mirror node client, to compare all slots taken by long strings
+     * @param {string} slot Base slot, to compare all slots taken by long string
+     * @param {string} address Address, to compare all slots taken by long string
+     */
+    const expectCorrectString = async (result, expectedString, client, slot, address) => {
+        if (expectedString.length > 31) {
+            const len = (expectedString.length * 2 + 1).toString(16).padStart(2, '0');
+            assert(result !== null);
+            expect(result.slice(2)).to.be.equal('0'.repeat(62) + len);
+
+            const baseSlot = BigInt(keccak256('0x' + toIntHex256(slot)));
+            let value = '';
+            for (let i = 0; i < (expectedString.length >> 5) + 1; i++) {
+                const result = await _getHtsStorageAt(
+                    address,
+                    `0x${(baseSlot + BigInt(i)).toString(16)}`,
+                    client
+                );
+                assert(result !== null);
+                value += result.slice(2);
+            }
+            const decoded = Buffer.from(value, 'hex')
+                .subarray(0, expectedString.length)
+                .toString('utf8');
+            expect(decoded).to.be.equal(expectedString);
+        } else {
+            const value = Buffer.from(expectedString).toString('hex').padEnd(62, '0');
+            const len = (expectedString.length * 2).toString(16).padStart(2, '0');
+            assert(result !== null);
+            expect(result.slice(2)).to.be.equal(value + len);
+        }
+    };
 
     Object.values(tokens)
-        .filter(t => ['USDC', 'MFCT'].includes(t.symbol))
+        .filter(t => ['USDC', 'MFCT', 'CFNFTFF'].includes(t.symbol))
         .forEach(({ symbol, address }) => {
             describe(`\`${symbol}(${address})\` token`, function () {
                 const tokenResult = require(`./data/${symbol}/getToken.json`);
@@ -197,31 +248,8 @@ describe('::getHtsStorageAt', function () {
                         if (str.length > 31) {
                             assert(this.test !== undefined);
                             this.test.title += ' (large string)';
-                            const len = (str.length * 2 + 1).toString(16).padStart(2, '0');
-                            assert(result !== null);
-                            expect(result.slice(2)).to.be.equal('0'.repeat(62) + len);
-
-                            const baseSlot = BigInt(keccak256('0x' + toIntHex256(slot)));
-                            let value = '';
-                            for (let i = 0; i < (str.length >> 5) + 1; i++) {
-                                const result = await _getHtsStorageAt(
-                                    address,
-                                    `0x${(baseSlot + BigInt(i)).toString(16)}`,
-                                    mirrorNodeClient
-                                );
-                                assert(result !== null);
-                                value += result.slice(2);
-                            }
-                            const decoded = Buffer.from(value, 'hex')
-                                .subarray(0, str.length)
-                                .toString('utf8');
-                            expect(decoded).to.be.equal(str);
-                        } else {
-                            const value = Buffer.from(str).toString('hex').padEnd(62, '0');
-                            const len = (str.length * 2).toString(16).padStart(2, '0');
-                            assert(result !== null);
-                            expect(result.slice(2)).to.be.equal(value + len);
                         }
+                        await expectCorrectString(result, str, mirrorNodeClient, slot, address);
                     });
                 });
 
@@ -236,14 +264,6 @@ describe('::getHtsStorageAt', function () {
                         );
                     });
                 });
-
-                /**
-                 * Pads `accountId` to be encoded within a storage slot.
-                 *
-                 * @param {number} accountId The `accountId` to pad.
-                 * @returns {string}
-                 */
-                const padAccountId = accountId => accountId.toString(16).padStart(8, '0');
 
                 /**@type{{name: string, fn: IMirrorNodeClient['getBalanceOfToken']}[]}*/ ([
                     {
@@ -277,48 +297,6 @@ describe('::getHtsStorageAt', function () {
                             balances.length === 0
                                 ? ZERO_HEX_32_BYTE
                                 : `0x${toIntHex256(balances[0].balance)}`
-                        );
-                    });
-                });
-
-                /**@type{{name: string, fn: IMirrorNodeClient['getAllowanceForToken']}[]}*/ ([
-                    {
-                        name: 'allowance is found',
-                        fn: (accountId, _tid, spenderId) =>
-                            require(
-                                `./data/${symbol}/getAllowanceForToken_${accountId}_${spenderId}`
-                            ),
-                    },
-                    {
-                        name: 'allowance is empty',
-                        fn: (_accountId, _tid, _spenderId) => ({ allowances: [] }),
-                    },
-                    {
-                        name: 'allowance is null',
-                        fn: (_accountId, _tid, _spenderId) => null,
-                    },
-                ]).forEach(({ name, fn: getAllowanceForToken }) => {
-                    const selector = id('allowance(address,address)').slice(0, 10);
-                    const padding = '0'.repeat(20 * 2);
-
-                    it(`should get \`allowance(${selector})\` of tokenId for encoded owner/spender when '${name}'`, async function () {
-                        const accountId = 4233295;
-                        const spenderId = 1335;
-                        const slot = `${selector}${padding}${padAccountId(spenderId)}${padAccountId(accountId)}`;
-                        const result = await _getHtsStorageAt(address, slot, {
-                            ...mirrorNodeClientStub,
-                            getAllowanceForToken,
-                        });
-
-                        const { allowances } = (await getAllowanceForToken(
-                            `0.0.${accountId}`,
-                            '<not used>',
-                            `0.0.${spenderId}`
-                        )) ?? { allowances: [] };
-                        expect(result).to.be.equal(
-                            allowances.length === 0
-                                ? ZERO_HEX_32_BYTE
-                                : `0x${toIntHex256(allowances[0].amount)}`
                         );
                     });
                 });
@@ -365,6 +343,156 @@ describe('::getHtsStorageAt', function () {
                         expect(result).to.be.equal(
                             tokens.length === 0 ? ZERO_HEX_32_BYTE : `0x${toIntHex256(1)}`
                         );
+                    });
+                });
+            });
+        });
+    Object.values(tokens)
+        .filter(t => ['USDC', 'MFCT'].includes(t.symbol))
+        .forEach(({ symbol, address }) => {
+            describe(`\`${symbol}(${address})\` token (fungible)`, function () {
+                /**@type{{name: string, fn: IMirrorNodeClient['getAllowanceForToken']}[]}*/ ([
+                    {
+                        name: 'allowance is found',
+                        fn: (accountId, _tid, spenderId) =>
+                            require(
+                                `./data/${symbol}/getAllowanceForToken_${accountId}_${spenderId}`
+                            ),
+                    },
+                    {
+                        name: 'allowance is empty',
+                        fn: (_accountId, _tid, _spenderId) => ({ allowances: [] }),
+                    },
+                    {
+                        name: 'allowance is null',
+                        fn: (_accountId, _tid, _spenderId) => null,
+                    },
+                ]).forEach(({ name, fn: getAllowanceForToken }) => {
+                    const selector = id('allowance(address,address)').slice(0, 10);
+                    const padding = '0'.repeat(20 * 2);
+
+                    it(`should get \`allowance(${selector})\` of tokenId for encoded owner/spender when '${name}'`, async function () {
+                        const accountId = 4233295;
+                        const spenderId = 1335;
+                        const slot = `${selector}${padding}${padAccountId(spenderId)}${padAccountId(accountId)}`;
+                        const result = await _getHtsStorageAt(address, slot, {
+                            ...mirrorNodeClientStub,
+                            getAllowanceForToken,
+                        });
+
+                        const { allowances } = (await getAllowanceForToken(
+                            `0.0.${accountId}`,
+                            '<not used>',
+                            `0.0.${spenderId}`
+                        )) ?? { allowances: [] };
+                        expect(result).to.be.equal(
+                            allowances.length === 0
+                                ? ZERO_HEX_32_BYTE
+                                : `0x${toIntHex256(allowances[0].amount)}`
+                        );
+                    });
+                });
+            });
+        });
+    Object.values(tokens)
+        .filter(t => t.symbol === 'CFNFTFF')
+        .forEach(({ symbol, address }) => {
+            describe(`\`${symbol}(${address})\` token (NFT)`, function () {
+                [1, 2].forEach(serialId => {
+                    const nftResult = require(
+                        `./data/${symbol}/getNonFungibleToken_${serialId}.json`
+                    );
+                    it(`should get owner of serial id ${serialId}`, async function () {
+                        const owner = nftResult['account_id'];
+                        const fakeEVMAddress = `0x${toIntHex256(serialId)}`;
+                        /** @type {IMirrorNodeClient} */
+                        const mirrorNodeClient = {
+                            ...mirrorNodeClientStub,
+                            getNftByTokenIdAndNumber(tokenId, _serial) {
+                                // https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.4271533/nfts/1
+                                expect(tokenId).to.be.equal(
+                                    nftResult.token_id,
+                                    'Invalid usage, provide the right address for token'
+                                );
+                                return nftResult;
+                            },
+                            getAccount(id) {
+                                expect(id).to.be.equal(
+                                    owner,
+                                    `Failed to extract owner of serial id ${serialId}`
+                                );
+                                return new Promise(resolve =>
+                                    resolve({
+                                        account: `0.0.${id}`,
+                                        evm_address: fakeEVMAddress,
+                                    })
+                                );
+                            },
+                        };
+                        const selector = id('ownerOf(uint256)').slice(0, 10);
+                        const padding = '0'.repeat(64 - 8 - `${serialId}`.length);
+                        const slot = `${selector}${padding}${serialId.toString(16)}`;
+                        const result = await _getHtsStorageAt(address, slot, mirrorNodeClient);
+                        expect(result).to.be.equal(fakeEVMAddress);
+                    });
+                    it(`should confirm approval for serial id ${serialId}`, async function () {
+                        const spender = nftResult['spender'];
+                        const fakeEVMAddress = `0x${toIntHex256(serialId)}`;
+                        /** @type {IMirrorNodeClient} */
+                        const mirrorNodeClient = {
+                            ...mirrorNodeClientStub,
+                            getNftByTokenIdAndNumber(tokenId, _serial) {
+                                // https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.4271533/nfts/1
+                                expect(tokenId).to.be.equal(
+                                    nftResult.token_id,
+                                    'Invalid usage, provide the right address for token'
+                                );
+                                return nftResult;
+                            },
+                            getAccount(id) {
+                                expect(id).to.be.equal(
+                                    spender,
+                                    `Failed to extract spender of serial id ${serialId}`
+                                );
+                                return new Promise(resolve =>
+                                    resolve({
+                                        account: `0.0.${id}`,
+                                        evm_address: fakeEVMAddress,
+                                    })
+                                );
+                            },
+                        };
+                        const selector = id('getApproved(uint256)').slice(0, 10);
+                        const padding = '0'.repeat(64 - 8 - `${serialId}`.length);
+                        const slot = `${selector}${padding}${serialId.toString(16)}`;
+                        const result = await _getHtsStorageAt(address, slot, mirrorNodeClient);
+                        expect(result).to.be.equal(
+                            spender ? fakeEVMAddress : `0x${toIntHex256(0)}`
+                        );
+                    });
+                    it(`should get storage for string field \`TokenURI\` for serial id ${serialId}`, async function () {
+                        /** @type {IMirrorNodeClient} */
+                        const mirrorNodeClient = {
+                            ...mirrorNodeClientStub,
+                            getNftByTokenIdAndNumber(tokenId, _serial) {
+                                // https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.4271533/nfts/1
+                                expect(tokenId).to.be.equal(
+                                    nftResult.token_id,
+                                    'Invalid usage, provide the right address for token'
+                                );
+                                return nftResult;
+                            },
+                        };
+                        const selector = id('tokenURI(uint256)').slice(0, 10);
+                        const padding = '0'.repeat(64 - 8 - `${serialId}`.length);
+                        const slot = `${selector}${padding}${serialId.toString(16)}`;
+                        const result = await _getHtsStorageAt(address, slot, mirrorNodeClient);
+                        const str = atob(nftResult['metadata']);
+                        if (str.length > 31) {
+                            assert(this.test !== undefined);
+                            this.test.title += ' (large string)';
+                        }
+                        await expectCorrectString(result, str, mirrorNodeClient, slot, address);
                     });
                 });
             });

--- a/test/scripts/json-rpc-mock.js
+++ b/test/scripts/json-rpc-mock.js
@@ -99,7 +99,7 @@ const mirrorNodeClient = {
         if (tokens[tokenId] === undefined) return null;
         return require(`../data/${tokens[tokenId].symbol}/getToken.json`);
     },
-    async getNftByTokenIdAndNumber(tokenId, serialId) {
+    async getNftByTokenIdAndSerial(tokenId, serialId) {
         this.append('getNonFungibleToken', tokenId, serialId);
         if (tokens[tokenId] === undefined) return null;
         return require(`../data/${tokens[tokenId].symbol}/getNonFungibleToken_${serialId}.json`);

--- a/test/scripts/json-rpc-mock.js
+++ b/test/scripts/json-rpc-mock.js
@@ -99,6 +99,11 @@ const mirrorNodeClient = {
         if (tokens[tokenId] === undefined) return null;
         return require(`../data/${tokens[tokenId].symbol}/getToken.json`);
     },
+    async getNftByTokenIdAndNumber(tokenId, serialId) {
+        this.append('getNonFungibleToken', tokenId, serialId);
+        if (tokens[tokenId] === undefined) return null;
+        return require(`../data/${tokens[tokenId].symbol}/getNonFungibleToken_${serialId}.json`);
+    },
     async getAccount(idOrAliasOrEvmAddress) {
         assert(!idOrAliasOrEvmAddress.startsWith('0x'));
         this.append('getAccount', idOrAliasOrEvmAddress);
@@ -122,6 +127,15 @@ const mirrorNodeClient = {
         if (tokens[tokenId] === undefined) return noAllowance;
         return requireOrDefault(
             `${tokens[tokenId].symbol}/getAllowanceForToken_${accountId}_${spenderId}.json`,
+            noAllowance
+        );
+    },
+    async getAllowanceForNFT(accountId, tokenId, operatorId) {
+        this.append('getAllowanceForNFT', accountId, tokenId, operatorId);
+        const noAllowance = { allowances: [] };
+        if (tokens[tokenId] === undefined) return noAllowance;
+        return requireOrDefault(
+            `${tokens[tokenId].symbol}/getAllowanceForToken_${accountId}_${operatorId}.json`,
             noAllowance
         );
     },


### PR DESCRIPTION
**Description**:
Implementing support for NFTs in the JS library for the JSON-RPC mock, as well as in the JSON-RPC server that utilizes this library.

#### The reason I've used persistent storage here:
We cannot determine which NFT numbers have been minted unless someone specifically queries them. This can be addressed in one of two ways:

1. Dynamic loading on first access: Load each NFT's details dynamically the first time its slot is queried. Once accessed, store information about the existence of this NFT. This is my current approach. However, this may result in a memory leak/optimisation when a large number of tests or NFT requests are made, as memory is never freed (this is where the name: persistentStorage comes from).

2. Preloading All NFTs: Load the details of all NFTs each time the token storage is accessed. While this avoids memory leaks, it could lead to excessive memory usage and generate a large number of unnecessary API requests for NFTs that we are not interested about :/ .

#### Why it might be an issue:
Let's consider scenario where:
1. We have a long tokenUri that spans more than one storage slot. 
2. Someone attempts to access the value in the second slot without first querying the initial slot.

We won’t be able to provide the correct result. This is because persistentStorage is only populated when the request for the first slot of the string is made (only then we can deduce the serial NFT number from the slot address). I don't think it's not a critical issue though...

**Related issue(s)**:

#80

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
