### PR TITLE
feat: implementation of `transferTokens` method (#200)

### DIFF
--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -125,6 +125,21 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
         return dissociateTokens(account, tokens);
     }
 
+    function transferTokens(
+        address token,
+        address[] memory accountId,
+        int64[] memory amount
+    ) htsCall external returns (int64 responseCode) {
+        require(token != address(0), "transferTokens: invalid token");
+        require(accountId.length > 0, "transferTokens: missing recipients");
+        require(amount.length == accountId.length, "transferTokens: inconsistent input");
+        for (uint256 i = 0; i < accountId.length; i++) {
+            responseCode = transferToken(token, msg.sender, accountId[i], amount[i]);
+            require(responseCode == HederaResponseCodes.SUCCESS, "transferTokens: transfer failed");
+        }
+        responseCode = HederaResponseCodes.SUCCESS;
+    }
+
     function transferNFTs(
         address token,
         address[] memory sender,

--- a/contracts/IHederaTokenService.sol
+++ b/contracts/IHederaTokenService.sol
@@ -462,11 +462,11 @@ interface IHederaTokenService {
     /// @param token The ID of the token as a solidity address
     /// @param accountId account to do a transfer to/from
     /// @param amount The amount from the accountId at the same index
-    // function transferTokens(
-    //     address token,
-    //     address[] memory accountId,
-    //     int64[] memory amount
-    // ) external returns (int64 responseCode);
+    function transferTokens(
+        address token,
+        address[] memory accountId,
+        int64[] memory amount
+    ) external returns (int64 responseCode);
 
     /// Initiates a Non-Fungable Token Transfer
     /// @param token The ID of the token as a solidity address


### PR DESCRIPTION
**Description**:
Added support for transfer tokens method on the hts address. When calling transferTokens on the 0x167 it will invoke the tokens transfer compatible with the hts based equivalent.

**Related issue(s)**:

Fixes #200

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
