### PR TITLE
fix: making it possible to access royalty fees and nft data (#217)

### DIFF
--- a/src/forwarder/mirror-node-client.js
+++ b/src/forwarder/mirror-node-client.js
@@ -65,12 +65,11 @@ class MirrorNodeClient {
      *
      * @param {string} tokenId the token ID to fetch.
      * @param {number} serialId the serial ID of the NFT to fetch.
-     * @param {number} blockNumber
+     * @param {number} _blockNumber
      * @returns {Promise<Record<string, unknown> | null>} a `Promise` resolving to the token information or null if not found.
      */
-    async getNftByTokenIdAndSerial(tokenId, serialId, blockNumber) {
-        const timestamp = await this.getBlockQueryParam(blockNumber);
-        return this._get(`tokens/${tokenId}/nft/${serialId}?${timestamp}`);
+    async getNftByTokenIdAndSerial(tokenId, serialId, _blockNumber) {
+        return this._get(`tokens/${tokenId}/nfts/${serialId}`);
     }
 
     /**

--- a/src/slotmap.js
+++ b/src/slotmap.js
@@ -267,7 +267,17 @@ function slotMapOf(token) {
         maximum_amount: fee['maximum'],
         fee_collector: fee['collector_account_id'],
     }));
-    token['royalty_fees'] = customFees['royalty_fees'] ?? [];
+    token['royalty_fees'] = (customFees['royalty_fees'] ?? []).map(fee => ({
+        all_collectors_are_exempt: fee['all_collectors_are_exempt'],
+        numerator: /**@type{{numerator: unknown}}*/ (fee['amount'])['numerator'],
+        denominator: /**@type{{denominator: unknown}}*/ (fee['amount'])['denominator'],
+        collector_account_id: fee['collector_account_id'],
+        amount: /**@type{{amount: unknown}}*/ (fee['fallback_fee'] || {})['amount'],
+        tokenId: /**@type{{denominating_token_id: unknown}}*/ (fee['fallback_fee'] || {})[
+            'denominating_token_id'
+        ],
+        fee_collector: fee['collector_account_id'],
+    }));
 
     const map = new SlotMap();
     storage.forEach(slot => visit(slot, 0n, token, '', map));


### PR DESCRIPTION
**Description**:
Applying the fix for the bugs described in this task:
https://github.com/hashgraph/hedera-forking/issues/217

It was not possible to get the data of the token which has royalty fees set.

There was also an issue whith accessing the data of the specific NFT (tokenURI).

Both of those problems are fixed in this PR.

**Related issue(s)**:

Fixes #217

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
