### PR TITLE
feat: making gettokeninfo and its dependants a view function (#164)

### DIFF
--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -361,27 +361,27 @@ contract HtsSystemContract is IHederaTokenService {
 
     function getTokenCustomFees(
         address token
-    ) htsCall external returns (int64, FixedFee[] memory, FractionalFee[] memory, RoyaltyFee[] memory) {
+    ) htsCall external view returns (int64, FixedFee[] memory, FractionalFee[] memory, RoyaltyFee[] memory) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         return (responseCode, tokenInfo.fixedFees, tokenInfo.fractionalFees, tokenInfo.royaltyFees);
     }
 
-    function getTokenDefaultFreezeStatus(address token) htsCall external returns (int64, bool) {
+    function getTokenDefaultFreezeStatus(address token) htsCall external view returns (int64, bool) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         return (responseCode, tokenInfo.token.freezeDefault);
     }
 
-    function getTokenDefaultKycStatus(address token) htsCall external returns (int64, bool) {
+    function getTokenDefaultKycStatus(address token) htsCall external view returns (int64, bool) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         return (responseCode, tokenInfo.defaultKycStatus);
     }
 
-    function getTokenExpiryInfo(address token) htsCall external returns (int64, Expiry memory expiry) {
+    function getTokenExpiryInfo(address token) htsCall external view returns (int64, Expiry memory expiry) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         return (responseCode, tokenInfo.token.expiry);
     }
 
-    function getFungibleTokenInfo(address token) htsCall external returns (int64, FungibleTokenInfo memory) {
+    function getFungibleTokenInfo(address token) htsCall external view returns (int64, FungibleTokenInfo memory) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         require(responseCode == HederaResponseCodes.SUCCESS, "getFungibleTokenInfo: failed to get token data");
         FungibleTokenInfo memory fungibleTokenInfo;
@@ -391,13 +391,13 @@ contract HtsSystemContract is IHederaTokenService {
         return (responseCode, fungibleTokenInfo);
     }
 
-    function getTokenInfo(address token) htsCall public returns (int64, TokenInfo memory) {
+    function getTokenInfo(address token) htsCall public view returns (int64, TokenInfo memory) {
         require(token != address(0), "getTokenInfo: invalid token");
 
         return IHederaTokenService(token).getTokenInfo(token);
     }
 
-    function getTokenKey(address token, uint keyType) htsCall external returns (int64, KeyValue memory) {
+    function getTokenKey(address token, uint keyType) htsCall view external returns (int64, KeyValue memory) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         require(responseCode == HederaResponseCodes.SUCCESS, "getTokenKey: failed to get token data");
         for (uint256 i = 0; i < tokenInfo.token.tokenKeys.length; i++) {
@@ -410,7 +410,7 @@ contract HtsSystemContract is IHederaTokenService {
     }
 
     function getNonFungibleTokenInfo(address token, int64 serialNumber)
-        htsCall external
+        htsCall external view
         returns (int64, NonFungibleTokenInfo memory) {
         (int64 responseCode, TokenInfo memory tokenInfo) = getTokenInfo(token);
         require(responseCode == HederaResponseCodes.SUCCESS, "getNonFungibleTokenInfo: failed to get token data");
@@ -427,13 +427,13 @@ contract HtsSystemContract is IHederaTokenService {
         return (responseCode, nonFungibleTokenInfo);
     }
 
-    function isToken(address token) htsCall external returns (int64, bool) {
+    function isToken(address token) htsCall external view returns (int64, bool) {
         bytes memory payload = abi.encodeWithSignature("getTokenType(address)", token);
-        (bool success, bytes memory returnData) = token.call(payload);
+        (bool success, bytes memory returnData) = token.staticcall(payload);
         return (HederaResponseCodes.SUCCESS, success && returnData.length > 0);
     }
 
-    function getTokenType(address token) htsCall external returns (int64, int32) {
+    function getTokenType(address token) htsCall external view returns (int64, int32) {
         require(token != address(0), "getTokenType: invalid address");
         return IHederaTokenService(token).getTokenType(token);
     }

--- a/contracts/IHederaTokenService.sol
+++ b/contracts/IHederaTokenService.sol
@@ -542,7 +542,7 @@ interface IHederaTokenService {
         address token,
         address owner,
         address spender
-    ) external returns (int64 responseCode, uint256 allowance);
+    ) external view returns (int64 responseCode, uint256 allowance);
 
     /// Allow or reaffirm the approved address to transfer an NFT the approved address does not own.
     /// Only Applicable to NFT Tokens
@@ -572,7 +572,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return approved The approved address for this NFT, or the zero address if there is none
     function getApproved(address token, uint256 serialNumber)
-        external
+        external view
         returns (int64 responseCode, address approved);
 
     /// Enable or disable approval for a third party ("operator") to manage
@@ -598,7 +598,7 @@ interface IHederaTokenService {
         address token,
         address owner,
         address operator
-    ) external returns (int64 responseCode, bool approved);
+    ) external view returns (int64 responseCode, bool approved);
 
     /// Query if token account is frozen
     /// @param token The token address to check
@@ -630,7 +630,7 @@ interface IHederaTokenService {
     /// @return fractionalFees Set of fractional fees for `token`
     /// @return royaltyFees Set of royalty fees for `token`
     function getTokenCustomFees(address token)
-        external
+        external view
         returns (int64 responseCode, FixedFee[] memory fixedFees, FractionalFee[] memory fractionalFees, RoyaltyFee[] memory royaltyFees);
 
     /// Query token default freeze status
@@ -638,7 +638,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return defaultFreezeStatus True if `token` default freeze status is frozen.
     function getTokenDefaultFreezeStatus(address token)
-        external
+        external view
         returns (int64 responseCode, bool defaultFreezeStatus);
 
     /// Query token default kyc status
@@ -646,7 +646,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return defaultKycStatus True if `token` default kyc status is KycNotApplicable and false if Revoked.
     function getTokenDefaultKycStatus(address token)
-        external
+        external view
         returns (int64 responseCode, bool defaultKycStatus);
 
     /// Query token expiry info
@@ -654,7 +654,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return expiry Expiry info for `token`
     function getTokenExpiryInfo(address token)
-        external
+        external view
         returns (int64 responseCode, Expiry memory expiry);
 
     /// Query fungible token info
@@ -662,7 +662,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return fungibleTokenInfo FungibleTokenInfo info for `token`
     function getFungibleTokenInfo(address token)
-        external
+        external view
         returns (int64 responseCode, FungibleTokenInfo memory fungibleTokenInfo);
 
     /// Query token info
@@ -670,7 +670,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return tokenInfo TokenInfo info for `token`
     function getTokenInfo(address token)
-        external
+        external view
         returns (int64 responseCode, TokenInfo memory tokenInfo);
 
     /// Query token KeyValue
@@ -679,7 +679,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return key KeyValue info for key of type `keyType`
     function getTokenKey(address token, uint keyType)
-        external
+        external view
         returns (int64 responseCode, KeyValue memory key);
 
     /// Query non fungible token info
@@ -688,7 +688,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return nonFungibleTokenInfo NonFungibleTokenInfo info for `token` `serialNumber`
     function getNonFungibleTokenInfo(address token, int64 serialNumber)
-        external
+        external view
         returns (int64 responseCode, NonFungibleTokenInfo memory nonFungibleTokenInfo);
 
     /// Operation to freeze token account
@@ -784,7 +784,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return isToken True if valid token found for the given address
     function isToken(address token)
-        external returns
+        external view returns
         (int64 responseCode, bool isToken);
 
     /// Query to return the token type for a given address
@@ -792,7 +792,7 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return tokenType the token type. 0 is FUNGIBLE_COMMON, 1 is NON_FUNGIBLE_UNIQUE, -1 is UNRECOGNIZED
     function getTokenType(address token)
-        external returns
+        external view returns
         (int64 responseCode, int32 tokenType);
 
     /// Initiates a Redirect For Token

--- a/examples/foundry-hts/USDC.t.sol
+++ b/examples/foundry-hts/USDC.t.sol
@@ -42,7 +42,7 @@ contract USDCExampleTest is Test {
         console.log("name: %s, symbol: %s, decimals: %d", name, symbol, decimals);
     }
 
-    function test_HTS_getTokenInfo() external {
+    function test_HTS_getTokenInfo() external view {
         (int64 responseCode, IHederaTokenService.TokenInfo memory tokenInfo) = IHederaTokenService(address(0x167)).getTokenInfo(USDC_mainnet);
         assertEq(responseCode, HederaResponseCodes.SUCCESS);
         assertEq(tokenInfo.token.name, "USD Coin");

--- a/test/HTS.t.sol
+++ b/test/HTS.t.sol
@@ -60,7 +60,7 @@ contract HTSTest is Test, TestSetup {
         assertTrue(revertsAsExpected, "expectRevert: call did not revert");
     }
 
-    function test_HTS_getTokenInfo_should_return_token_info_for_valid_token() external {
+    function test_HTS_getTokenInfo_should_return_token_info_for_valid_token() external view {
         address token = USDC;
         (int64 responseCode, IHederaTokenService.TokenInfo memory tokenInfo) = IHederaTokenService(HTS_ADDRESS).getTokenInfo(token);
         assertEq(responseCode, HederaResponseCodes.SUCCESS);
@@ -107,7 +107,7 @@ contract HTSTest is Test, TestSetup {
         assertEq(tokenInfo.ledgerId, testMode == TestMode.FFI ? "0x01" : "0x00");
     }
 
-    function test_HTS_getTokenInfo_should_return_custom_fees_for_valid_token() external {
+    function test_HTS_getTokenInfo_should_return_custom_fees_for_valid_token() external view {
         (int64 responseCode, IHederaTokenService.TokenInfo memory tokenInfo) = IHederaTokenService(HTS_ADDRESS).getTokenInfo(CTCF);
         assertEq(responseCode, HederaResponseCodes.SUCCESS);
         assertEq(tokenInfo.token.name, "Crypto Token with Custom Fees");
@@ -349,7 +349,7 @@ contract HTSTest is Test, TestSetup {
         assertFalse(isApproved);
     }
 
-    function test_HTS_getTokenCustomFees_should_return_custom_fees_for_valid_token() external {
+    function test_HTS_getTokenCustomFees_should_return_custom_fees_for_valid_token() external view {
         (
             int64 responseCode,
             IHederaTokenService.FixedFee[] memory fixedFees,
@@ -397,21 +397,21 @@ contract HTSTest is Test, TestSetup {
         assertEq(royaltyFees.length, 0);
     }
 
-    function test_HTS_getTokenDefaultFreezeStatus_should_return_correct_value_for_valid_token() external {
+    function test_HTS_getTokenDefaultFreezeStatus_should_return_correct_value_for_valid_token() external view {
         address token = CFNFTFF;
         (int64 freezeStatus, bool defaultFreeze) = IHederaTokenService(HTS_ADDRESS).getTokenDefaultFreezeStatus(token);
         assertEq(freezeStatus, HederaResponseCodes.SUCCESS);
         assertFalse(defaultFreeze);
     }
 
-    function test_HTS_getTokenDefaultKycStatus_should_return_correct_value_for_valid_token() external {
+    function test_HTS_getTokenDefaultKycStatus_should_return_correct_value_for_valid_token() external view {
         address token = CFNFTFF;
         (int64 kycStatus, bool defaultKyc) = IHederaTokenService(HTS_ADDRESS).getTokenDefaultKycStatus(token);
         assertEq(kycStatus, HederaResponseCodes.SUCCESS);
         assertFalse(defaultKyc);
     }
 
-    function test_HTS_getTokenExpiryInfo_should_return_correct_value_for_valid_token() external {
+    function test_HTS_getTokenExpiryInfo_should_return_correct_value_for_valid_token() external view {
         (int64 expiryStatusCode, IHederaTokenService.Expiry memory expiry)
             = IHederaTokenService(HTS_ADDRESS).getTokenExpiryInfo(USDC);
         assertEq(expiryStatusCode, HederaResponseCodes.SUCCESS);
@@ -420,7 +420,7 @@ contract HTSTest is Test, TestSetup {
         assertEq(expiry.autoRenewPeriod, 0);
     }
 
-    function test_HTS_getTokenKey_should_return_correct_key_value() external {
+    function test_HTS_getTokenKey_should_return_correct_key_value() external view {
         address token = USDC;
 
         // AdminKey
@@ -452,7 +452,7 @@ contract HTSTest is Test, TestSetup {
         assertEq(supplyKey.delegatableContractId, address(0));
     }
 
-    function test_HTS_getTokenType_should_return_correct_token_type_for_existing_token() external {
+    function test_HTS_getTokenType_should_return_correct_token_type_for_existing_token() external view {
         (int64 ftTypeStatusCode, int32 ftType) = IHederaTokenService(HTS_ADDRESS).getTokenType(USDC);
         assertEq(ftTypeStatusCode, HederaResponseCodes.SUCCESS);
         assertEq(ftType, int32(0));
@@ -462,7 +462,7 @@ contract HTSTest is Test, TestSetup {
         assertEq(nftType, int32(1));
     }
 
-    function test_HTS_isToken_should_return_correct_is_token_info() external {
+    function test_HTS_isToken_should_return_correct_is_token_info() external view {
         (int64 ftIsTokenStatusCode, bool ftIsToken) = IHederaTokenService(HTS_ADDRESS).isToken(USDC);
         assertEq(ftIsTokenStatusCode, HederaResponseCodes.SUCCESS);
         assertTrue(ftIsToken);
@@ -545,7 +545,7 @@ contract HTSTest is Test, TestSetup {
         IHederaTokenService(HTS_ADDRESS).dissociateTokens(bob, tokens);
     }
 
-    function test_HTS_get_fungible_token_info() external {
+    function test_HTS_get_fungible_token_info() external view {
         (int64 fungibleResponseCode, IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo)
             = IHederaTokenService(HTS_ADDRESS).getFungibleTokenInfo(USDC);
         assertEq(fungibleResponseCode, HederaResponseCodes.SUCCESS);
@@ -594,7 +594,7 @@ contract HTSTest is Test, TestSetup {
         assertEq(fungibleTokenInfo.tokenInfo.ledgerId, testMode == TestMode.FFI ? "0x01" : "0x00");
     }
 
-    function test_HTS_get_non_fungible_token_info() external {
+    function test_HTS_get_non_fungible_token_info() external view {
         (int64 nonFungibleResponseCode, IHederaTokenService.NonFungibleTokenInfo memory nonFungibleTokenInfo)
             = IHederaTokenService(HTS_ADDRESS).getNonFungibleTokenInfo(CFNFTFF, int64(1));
         assertEq(nonFungibleResponseCode, HederaResponseCodes.SUCCESS);
@@ -786,7 +786,7 @@ contract HTSTest is Test, TestSetup {
         vm.stopPrank();
     }
 
-    function test_HTS_allowance_from_remote() external {
+    function test_HTS_allowance_from_remote() external view {
         // https://hashscan.io/testnet/account/0.0.4233295
         address owner = address(0x000000000000000000000000000000000040984F);
         // https://hashscan.io/testnet/account/0.0.1335


### PR DESCRIPTION
**Description**:

Makes HTS(address(0x167)).getTokenInfo and every other getters in the HTS become views.

**Related issue(s)**:

Fixes #164

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
