### PR TITLE
feat: getnftinfo will return its metadata and creation time

### DIFF
--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+import {decode} from './Base64.sol';
 import {IERC20} from "./IERC20.sol";
 import {IERC721} from "./IERC721.sol";
 import {IHRC719} from "./IHRC719.sol";
@@ -879,12 +880,6 @@ contract HtsSystemContract is IHederaTokenService {
         return bytes32(abi.encodePacked(selector, pad, accountId));
     }
 
-    function _tokenUriSlot(uint32 serialId) internal virtual returns (bytes32) {
-        bytes4 selector = IERC721.tokenURI.selector;
-        uint192 pad = 0x0;
-        return bytes32(abi.encodePacked(selector, pad, serialId));
-    }
-
     function __nftInfoSlot(uint32 serialId) internal virtual returns (bytes32) {
         bytes4 selector = IHederaTokenService.getNonFungibleTokenInfo.selector;
         uint192 pad = 0x0;
@@ -921,11 +916,9 @@ contract HtsSystemContract is IHederaTokenService {
         assembly { amount := sload(slot) }
     }
 
-    function __tokenURI(uint256 serialId) private returns (string memory uri) {
-        bytes32 slot = _tokenUriSlot(uint32(serialId));
-        string storage _uri;
-        assembly { _uri.slot := slot }
-        uri = _uri;
+    function __tokenURI(uint256 serialId) private returns (string memory) {
+        (, bytes memory metadata) = __nftInfo(serialId);
+        return string(decode(string(metadata)));
     }
 
     function __nftInfo(uint256 serialId) private returns (int64, bytes memory) {

--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -444,9 +444,9 @@ contract HtsSystemContract is IHederaTokenService {
         );
         nonFungibleTokenInfo.tokenInfo = tokenInfo;
         nonFungibleTokenInfo.serialNumber = serialNumber;
-        uint256 serial = uint256(uint64(serialNumber));
-        nonFungibleTokenInfo.spenderId = IERC721(token).getApproved(serial);
-        nonFungibleTokenInfo.ownerId = IERC721(token).ownerOf(serial);
+        nonFungibleTokenInfo.spenderId = IERC721(token).getApproved(uint256(uint64(serialNumber)));
+        nonFungibleTokenInfo.ownerId = IERC721(token).ownerOf(uint256(uint64(serialNumber)));
+
         return (responseCode, nonFungibleTokenInfo);
     }
 

--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -505,6 +505,17 @@ contract HtsSystemContractJson is HtsSystemContract {
         return slot;
     }
 
+    function __nftInfoSlot(uint32 serialId) internal override virtual returns (bytes32) {
+        bytes32 slot = super.__nftInfoSlot(serialId);
+        if (_shouldFetch(slot)) {
+            string memory metadata = mirrorNode().getNftMetadata(address(this), serialId);
+            string memory createdTimestamp = mirrorNode().getNftCreatedTimestamp(address(this), serialId);
+            int64 creationTime = int64(vm.parseInt(vm.split(createdTimestamp, ".")[0]));
+            storeBytes(address(this), uint256(slot), abi.encode(creationTime, bytes(metadata)));
+        }
+        return slot;
+    }
+
     function _ownerOfSlot(uint32 serialId) internal override virtual returns (bytes32) {
         bytes32 slot = super._ownerOfSlot(serialId);
         if (_shouldFetch(slot)) {

--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -498,9 +498,10 @@ contract HtsSystemContractJson is HtsSystemContract {
     function _tokenUriSlot(uint32 serialId) internal override virtual returns (bytes32) {
         bytes32 slot = super._tokenUriSlot(serialId);
         if (_shouldFetch(slot)) {
-            string memory metadata = mirrorNode().getNftMetadata(address(this), serialId);
+            (string memory metadata, ) = mirrorNode().getNftMetadataAndCreatedTimestamp(address(this), serialId);
             string memory uri = string(decode(metadata));
             storeString(address(this), uint256(slot), uri);
+            vm.store(_scratchAddr(), slot, bytes32(uint(1)));
         }
         return slot;
     }
@@ -508,10 +509,13 @@ contract HtsSystemContractJson is HtsSystemContract {
     function __nftInfoSlot(uint32 serialId) internal override virtual returns (bytes32) {
         bytes32 slot = super.__nftInfoSlot(serialId);
         if (_shouldFetch(slot)) {
-            string memory metadata = mirrorNode().getNftMetadata(address(this), serialId);
-            string memory createdTimestamp = mirrorNode().getNftCreatedTimestamp(address(this), serialId);
+            (string memory metadata, string memory createdTimestamp) = mirrorNode().getNftMetadataAndCreatedTimestamp(
+                address(this),
+                serialId
+            );
             int64 creationTime = int64(vm.parseInt(vm.split(createdTimestamp, ".")[0]));
             storeBytes(address(this), uint256(slot), abi.encode(creationTime, bytes(metadata)));
+            vm.store(_scratchAddr(), slot, bytes32(uint(1)));
         }
         return slot;
     }

--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {Vm} from "forge-std/Vm.sol";
-import {decode} from './Base64.sol';
 import {IHederaTokenService} from "./IHederaTokenService.sol";
 import {HtsSystemContract, HTS_ADDRESS} from "./HtsSystemContract.sol";
 import {IERC20} from "./IERC20.sol";
@@ -491,17 +490,6 @@ contract HtsSystemContractJson is HtsSystemContract {
         if (_shouldFetch(slot)) {
             bool associated = mirrorNode().isAssociated(address(this), account);
             _setValue(slot, bytes32(uint256(associated ? 1 : 0)));
-        }
-        return slot;
-    }
-
-    function _tokenUriSlot(uint32 serialId) internal override virtual returns (bytes32) {
-        bytes32 slot = super._tokenUriSlot(serialId);
-        if (_shouldFetch(slot)) {
-            (string memory metadata, ) = mirrorNode().getNftMetadataAndCreatedTimestamp(address(this), serialId);
-            string memory uri = string(decode(metadata));
-            storeString(address(this), uint256(slot), uri);
-            vm.store(_scratchAddr(), slot, bytes32(uint(1)));
         }
         return slot;
     }

--- a/contracts/MirrorNode.sol
+++ b/contracts/MirrorNode.sol
@@ -30,26 +30,24 @@ abstract contract MirrorNode {
 
     function fetchTokenRelationshipOfAccount(string memory account, address token) external virtual returns (string memory json);
 
-    function fetchNonFungibleToken(address token, uint32 serial) external virtual returns (string memory json);
+    function fetchNonFungibleTokenSerial(address token, uint32 serial) external virtual returns (string memory json);
 
-    function getNftMetadata(address token, uint32 serial) external returns (string memory) {
-        string memory json = this.fetchNonFungibleToken(token, serial);
+    function getNftMetadataAndCreatedTimestamp(address token, uint32 serial) external returns (string memory metadata, string memory createdTimestamp) {
+        string memory json = this.fetchNonFungibleTokenSerial(token, serial);
         if (vm.keyExistsJson(json, ".metadata")) {
-            return vm.parseJsonString(json, ".metadata");
+            metadata = vm.parseJsonString(json, ".metadata");
+        } else {
+            metadata = "";
         }
-        return "";
-    }
-
-    function getNftCreatedTimestamp(address token, uint32 serial) external returns (string memory) {
-        string memory json = this.fetchNonFungibleToken(token, serial);
         if (vm.keyExistsJson(json, ".created_timestamp")) {
-            return vm.parseJsonString(json, ".created_timestamp");
+            createdTimestamp = vm.parseJsonString(json, ".created_timestamp");
+        } else {
+            createdTimestamp = "";
         }
-        return "";
     }
 
     function getNftOwner(address token, uint32 serial) external returns (address) {
-        string memory json = this.fetchNonFungibleToken(token, serial);
+        string memory json = this.fetchNonFungibleTokenSerial(token, serial);
         if (vm.keyExistsJson(json, ".account_id")) {
             string memory owner = vm.parseJsonString(json, ".account_id");
             return getAccountAddress(owner);
@@ -58,7 +56,7 @@ abstract contract MirrorNode {
     }
 
     function getNftSpender(address token, uint32 serial) external returns (address) {
-        string memory json = this.fetchNonFungibleToken(token, serial);
+        string memory json = this.fetchNonFungibleTokenSerial(token, serial);
         if (vm.keyExistsJson(json, ".spender")) {
             string memory spender = vm.parseJsonString(json, ".spender");
             return getAccountAddress(spender);

--- a/contracts/MirrorNode.sol
+++ b/contracts/MirrorNode.sol
@@ -40,6 +40,14 @@ abstract contract MirrorNode {
         return "";
     }
 
+    function getNftCreatedTimestamp(address token, uint32 serial) external returns (string memory) {
+        string memory json = this.fetchNonFungibleToken(token, serial);
+        if (vm.keyExistsJson(json, ".created_timestamp")) {
+            return vm.parseJsonString(json, ".created_timestamp");
+        }
+        return "";
+    }
+
     function getNftOwner(address token, uint32 serial) external returns (address) {
         string memory json = this.fetchNonFungibleToken(token, serial);
         if (vm.keyExistsJson(json, ".account_id")) {

--- a/contracts/MirrorNodeFFI.sol
+++ b/contracts/MirrorNodeFFI.sol
@@ -82,7 +82,7 @@ contract MirrorNodeFFI is MirrorNode {
         ));
     }
 
-    function fetchNonFungibleToken(address token, uint32 serial) isValid(token) external override returns (string memory) {
+    function fetchNonFungibleTokenSerial(address token, uint32 serial) isValid(token) external override returns (string memory) {
         return _get(string.concat(
             "tokens/0.0.",
             vm.toString(uint160(token)),

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
             tokenId,
             blockNumber,
             nrequestedSlot,
-            atob(metadata),
+            Buffer.from(metadata, 'base64').toString(),
             't_string_storage'
         );
     }
@@ -273,7 +273,7 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
                 `Failed to get the metadata of the NFT ${tokenId}#${serialId}`
             );
         const timestamp = Number(created_timestamp.split('.')[0]).toString(16).padStart(64, '0');
-        const metadataEncoded = Buffer.from(metadata).toString('hex');
+        const metadataEncoded = Buffer.from(metadata, 'utf-8').toString('hex');
         const metadataLength = metadata.length.toString(16).padStart(64, '0');
         const stringTypeIndicator = '40'.padStart(64, '0');
         const bytes = `${timestamp}${stringTypeIndicator}${metadataLength}${metadataEncoded}`;

--- a/src/slotmap.js
+++ b/src/slotmap.js
@@ -323,10 +323,11 @@ class PersistentStorageMap {
      * @param {number} blockNumber
      * @param {bigint} slot
      * @param {Value} value
+     * @param {string} type
      */
-    store(tokenId, blockNumber, slot, value) {
+    store(tokenId, blockNumber, slot, value, type) {
         visit(
-            { label: 'value', slot: slot.toString(), type: 't_string_storage', offset: 0 },
+            { label: 'value', slot: slot.toString(), type, offset: 0 },
             0n,
             { value },
             '',

--- a/src/slotmap.js
+++ b/src/slotmap.js
@@ -323,7 +323,7 @@ class PersistentStorageMap {
      * @param {number} blockNumber
      * @param {bigint} slot
      * @param {Value} value
-     * @param {string} type
+     * @param {'t_string_storage' | 't_bytes_storage'} type
      */
     store(tokenId, blockNumber, slot, value, type) {
         visit(

--- a/src/slotmap.js
+++ b/src/slotmap.js
@@ -323,11 +323,10 @@ class PersistentStorageMap {
      * @param {number} blockNumber
      * @param {bigint} slot
      * @param {Value} value
-     * @param {'t_string_storage' | 't_bytes_storage'} type
      */
-    store(tokenId, blockNumber, slot, value, type) {
+    store(tokenId, blockNumber, slot, value) {
         visit(
-            { label: 'value', slot: slot.toString(), type, offset: 0 },
+            { label: 'value', slot: slot.toString(), type: 't_bytes_storage', offset: 0 },
             0n,
             { value },
             '',

--- a/test/HTS.t.sol
+++ b/test/HTS.t.sol
@@ -688,6 +688,13 @@ contract HTSTest is Test, TestSetup {
         assertEq(nonFungibleTokenInfo.tokenInfo.fractionalFees.length, 0);
         assertEq(nonFungibleTokenInfo.tokenInfo.royaltyFees.length, 0);
         assertEq(nonFungibleTokenInfo.tokenInfo.ledgerId, testMode == TestMode.FFI ? "0x01" : "0x00");
+
+        // Additional information, not a part of the IERC721 interface.
+        assertEq(
+            string(nonFungibleTokenInfo.metadata),
+            "aHR0cHM6Ly92ZXJ5LWxvbmctc3RyaW5nLXdoaWNoLWV4Y2VlZHMtMzEtYnl0ZXMtYW5kLXJlcXVpcmVzLW11bHRpcGxlLXN0b3JhZ2Utc2xvdHMuY29tLzE="
+        );
+        assertEq(nonFungibleTokenInfo.creationTime, 1734948254);
     }
 
     function test_HTS_transferToken() external {

--- a/test/getHtsStorageAt.test.js
+++ b/test/getHtsStorageAt.test.js
@@ -141,44 +141,6 @@ describe('::getHtsStorageAt', function () {
      */
     const padAccountId = accountId => accountId.toString(16).padStart(8, '0');
 
-    /**
-     * Pads `accountId` to be encoded within a storage slot.
-     *
-     * @param {string|null} result Response returned by eth_getStorageAt
-     * @param {string} expectedString Expected string.
-     * @param {IMirrorNodeClient} client Mirror node client, to compare all slots taken by long strings
-     * @param {string} slot Base slot, to compare all slots taken by long string
-     * @param {string} address Address, to compare all slots taken by long string
-     */
-    const expectCorrectString = async (result, expectedString, client, slot, address) => {
-        if (expectedString.length > 31) {
-            const len = (expectedString.length * 2 + 1).toString(16).padStart(2, '0');
-            assert(result !== null);
-            expect(result.slice(2)).to.be.equal('0'.repeat(62) + len);
-
-            const baseSlot = BigInt(keccak256('0x' + toIntHex256(slot)));
-            let value = '';
-            for (let i = 0; i < (expectedString.length >> 5) + 1; i++) {
-                const result = await _getHtsStorageAt(
-                    address,
-                    `0x${(baseSlot + BigInt(i)).toString(16)}`,
-                    client
-                );
-                assert(result !== null);
-                value += result.slice(2);
-            }
-            const decoded = Buffer.from(value, 'hex')
-                .subarray(0, expectedString.length)
-                .toString('utf8');
-            expect(decoded).to.be.equal(expectedString);
-        } else {
-            const value = Buffer.from(expectedString).toString('hex').padEnd(62, '0');
-            const len = (expectedString.length * 2).toString(16).padStart(2, '0');
-            assert(result !== null);
-            expect(result.slice(2)).to.be.equal(value + len);
-        }
-    };
-
     Object.values(tokens)
         .filter(t => ['USDC', 'MFCT', 'CFNFTFF'].includes(t.symbol))
         .forEach(({ symbol, address }) => {
@@ -420,7 +382,7 @@ describe('::getHtsStorageAt', function () {
                             spender ? fakeEVMAddress : `0x${toIntHex256(0)}`
                         );
                     });
-                    it(`should get storage for string field \`TokenURI\` for serial id ${serialId}`, async function () {
+                    it(`should get storage for packed field with \`created_timestamp\` and \`metadata\` for serial id ${serialId}`, async function () {
                         /** @type {IMirrorNodeClient} */
                         const mirrorNodeClient = {
                             ...mirrorNodeClientStub,
@@ -432,17 +394,52 @@ describe('::getHtsStorageAt', function () {
                                 );
                                 return nftResult;
                             },
+                            getTokenById: async () => require(`./data/USDC/getToken.json`),
                         };
-                        const selector = id('tokenURI(uint256)').slice(0, 10);
+                        const selector = id('getNonFungibleTokenInfo(address,int64)').slice(0, 10);
                         const padding = '0'.repeat(64 - 8 - `${serialId}`.length);
                         const slot = `${selector}${padding}${serialId.toString(16)}`;
-                        const result = await _getHtsStorageAt(address, slot, mirrorNodeClient);
-                        const str = atob(nftResult['metadata']);
-                        if (str.length > 31) {
-                            assert(this.test !== undefined);
-                            this.test.title += ' (large string)';
-                        }
-                        await expectCorrectString(result, str, mirrorNodeClient, slot, address);
+                        const baseResult =
+                            (await _getHtsStorageAt(address, slot, mirrorNodeClient)) || '0';
+
+                        // The total number of bytes occupied by this tuple cannot be smaller.
+                        // While the size of the metadata string is unknown, we must store a uint256,
+                        // followed by the offset and string length fields.
+                        expect(parseInt(baseResult, 16)).to.be.greaterThan(96);
+                        const baseSlotOfPackedValue = BigInt(keccak256('0x' + toIntHex256(slot)));
+                        const createdSlot = baseSlotOfPackedValue + BigInt(0);
+                        const createdSlotResult =
+                            (await _getHtsStorageAt(
+                                address,
+                                `0x${createdSlot.toString(16)}`,
+                                mirrorNodeClient
+                            )) || 0;
+                        const expectedTimestamp = BigInt(
+                            nftResult['created_timestamp'].split('.')[0]
+                        );
+                        expect(BigInt(createdSlotResult)).to.be.equal(expectedTimestamp);
+                        const offsetSlot = baseSlotOfPackedValue + BigInt(1);
+                        const offsetResult =
+                            (await _getHtsStorageAt(
+                                address,
+                                `0x${offsetSlot.toString(16)}`,
+                                mirrorNodeClient
+                            )) || 0;
+
+                        // Our encoded data will always have the same structure:
+                        //      (uint256,string)
+                        // so the offset for string should be 64 bytes
+                        expect(BigInt(offsetResult)).to.be.equal(BigInt(64));
+                        const metadataSlot = baseSlotOfPackedValue + BigInt(2);
+                        const metadataResult =
+                            (await _getHtsStorageAt(
+                                address,
+                                `0x${metadataSlot.toString(16)}`,
+                                mirrorNodeClient
+                            )) || 0;
+                        expect(BigInt(metadataResult)).to.be.equal(
+                            BigInt(nftResult['metadata'].length)
+                        );
                     });
                 });
             });

--- a/test/lib/MirrorNodeMock.sol
+++ b/test/lib/MirrorNodeMock.sol
@@ -58,7 +58,7 @@ contract MirrorNodeMock is MirrorNode {
         return vm.readFile(path);
     }
 
-    function fetchNonFungibleToken(address token, uint32 serial) external override view returns (string memory) {
+    function fetchNonFungibleTokenSerial(address token, uint32 serial) external override view returns (string memory) {
         string memory symbol = _symbolOf[token];
         string memory serialId = vm.toString(serial);
         string memory path = string.concat("./test/data/", symbol, "/getNonFungibleToken_", serialId, ".json");


### PR DESCRIPTION
**Description**:

A call to the getNonFungibleTokenInfo method on the HTS address (0x167) will now correctly populate the "metadata" and "creationTime" fields.

**Related issue(s)**:

Fixes #198

**Notes for reviewer**:

Until now, these fields were mocked because they were not supported by IERC721 and required a direct implementation.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
