### PR TITLE
167 fetching the information who owns the keys the token is associated with

### DIFF
--- a/contracts/BytesToString.sol
+++ b/contracts/BytesToString.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity >=0.6.0;
+
+function bytesToString(bytes memory data) pure returns (string memory) {
+    bytes memory HEX_SYMBOLS = "0123456789abcdef";
+    bytes memory buffer = new bytes(2 + data.length * 2);
+    buffer[0] = "0";
+    buffer[1] = "x";
+    for (uint i = 0; i < data.length; i++) {
+        buffer[2 + i * 2] = HEX_SYMBOLS[uint8(data[i]) >> 4];
+        buffer[3 + i * 2] = HEX_SYMBOLS[uint8(data[i]) & 0x0f];
+    }
+    return string(buffer);
+}

--- a/contracts/HederaResponseCodes.sol
+++ b/contracts/HederaResponseCodes.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.8.0;
 
 library HederaResponseCodes {
     int32 internal constant SUCCESS = 22; // The transaction succeeded
+    int32 internal constant TOKEN_HAS_NO_SUPPLY_KEY = 180;
 }

--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -66,6 +66,9 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
         (int64 tokenInfoResponseCode, TokenInfo memory tokenInfo) = IHederaTokenService(token).getTokenInfo(token);
         require(tokenInfoResponseCode == HederaResponseCodes.SUCCESS, "mintToken: failed to get token info");
 
+        if (tokenInfo.token.treasury == address(0)) {
+            return (HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY, tokenInfo.totalSupply, new int64[](0));
+        }
         address treasuryAccount = tokenInfo.token.treasury;
         require(treasuryAccount != address(0), "mintToken: invalid account");
 
@@ -87,6 +90,9 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
         (int64 tokenInfoResponseCode, TokenInfo memory tokenInfo) = IHederaTokenService(token).getTokenInfo(token);
         require(tokenInfoResponseCode == HederaResponseCodes.SUCCESS, "burnToken: failed to get token info");
 
+        if (tokenInfo.token.treasury == address(0)) {
+            return (HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY, tokenInfo.totalSupply);
+        }
         address treasuryAccount = tokenInfo.token.treasury;
         require(treasuryAccount != address(0), "burnToken: invalid account");
 

--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -15,7 +15,7 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
     /**
      * The slot's value contains the next token ID to use when a token is being created.
      *
-     * This slot is used in the `0x167` address. 
+     * This slot is used in the `0x167` address.
      * It cannot be used as a state variable directly.
      * This is because JS' `getHtsStorageAt` implementation assumes all state variables
      * declared here are part of the token address space.
@@ -28,7 +28,7 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
     // See `__redirectForToken` for more details.
     //
     // Moreover, these variables must match the slots defined in `SetTokenInfo`.
-    string internal tokenType; 
+    string internal tokenType;
     uint8 internal decimals;
     TokenInfo internal _tokenInfo;
 
@@ -66,11 +66,10 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
         (int64 tokenInfoResponseCode, TokenInfo memory tokenInfo) = IHederaTokenService(token).getTokenInfo(token);
         require(tokenInfoResponseCode == HederaResponseCodes.SUCCESS, "mintToken: failed to get token info");
 
-        if (tokenInfo.token.treasury == address(0)) {
+        address treasuryAccount = tokenInfo.token.treasury;
+        if (treasuryAccount == address(0)) {
             return (HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY, tokenInfo.totalSupply, new int64[](0));
         }
-        address treasuryAccount = tokenInfo.token.treasury;
-        require(treasuryAccount != address(0), "mintToken: invalid account");
 
         HtsSystemContract(token)._update(address(0), treasuryAccount, uint256(uint64(amount)));
 
@@ -90,11 +89,10 @@ contract HtsSystemContract is IHederaTokenService, IERC20Events, IERC721Events {
         (int64 tokenInfoResponseCode, TokenInfo memory tokenInfo) = IHederaTokenService(token).getTokenInfo(token);
         require(tokenInfoResponseCode == HederaResponseCodes.SUCCESS, "burnToken: failed to get token info");
 
-        if (tokenInfo.token.treasury == address(0)) {
+        address treasuryAccount = tokenInfo.token.treasury;
+        if (treasuryAccount == address(0)) {
             return (HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY, tokenInfo.totalSupply);
         }
-        address treasuryAccount = tokenInfo.token.treasury;
-        require(treasuryAccount != address(0), "burnToken: invalid account");
 
         HtsSystemContract(token)._update(treasuryAccount, address(0), uint256(uint64(amount)));
 

--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -62,7 +62,7 @@ contract HtsSystemContractJson is HtsSystemContract {
         return uint32(bytes4(keccak256(abi.encodePacked(account))));
     }
 
-    function getEd25519KeyAddress(string memory publicKey) htsCall external override returns (address accountAddress) {
+    function getAddressFromKey(string memory publicKey) htsCall external override returns (address accountAddress) {
         return mirrorNode().getAccountAddressByPublicKey(publicKey);
     }
 

--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -62,6 +62,10 @@ contract HtsSystemContractJson is HtsSystemContract {
         return uint32(bytes4(keccak256(abi.encodePacked(account))));
     }
 
+    function getEd25519KeyAddress(string memory publicKey) htsCall external override returns (address accountAddress) {
+        return mirrorNode().getAccountAddressByPublicKey(publicKey);
+    }
+
     function __redirectForToken() internal override returns (bytes memory) {
         HtsSystemContractJson(HTS_ADDRESS).allowCheatcodes(address(this));
         return super.__redirectForToken();

--- a/contracts/ITokenKey.sol
+++ b/contracts/ITokenKey.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * This interface is used to get the selectors and for testing.
+ */
+interface ITokenKey {
+    /**
+     * @dev Returns the account associated with the key type assigned tot the token.
+     */
+    function getKeyAddress(uint keyType) external view returns (address accountAddress);
+}

--- a/contracts/MirrorNode.sol
+++ b/contracts/MirrorNode.sol
@@ -28,6 +28,8 @@ abstract contract MirrorNode {
 
     function fetchAccount(string memory account) external virtual returns (string memory json);
 
+    function fetchAccountByPublicKey(string memory publicKey) external virtual returns (string memory json);
+
     function fetchTokenRelationshipOfAccount(string memory account, address token) external virtual returns (string memory json);
 
     function fetchNonFungibleToken(address token, uint32 serial) external virtual returns (string memory json);
@@ -99,6 +101,18 @@ abstract contract MirrorNode {
             }
         } catch {}
         return false;
+    }
+
+    function getAccountAddressByPublicKey(string memory publicKey) public returns (address) {
+        try this.fetchAccountByPublicKey(publicKey) returns (string memory json) {
+            if (vm.keyExistsJson(json, ".accounts[0].evm_address")) {
+                return vm.parseJsonAddress(json, ".accounts[0].evm_address");
+            }
+        } catch {
+            // Do nothing
+        }
+        // generate a deterministic address based on the account public key as a fallback
+        return address(uint160(uint256(keccak256(bytes(publicKey)))));
     }
 
     function getAccountAddress(string memory accountId) public returns (address) {

--- a/contracts/MirrorNodeFFI.sol
+++ b/contracts/MirrorNodeFFI.sol
@@ -71,6 +71,10 @@ contract MirrorNodeFFI is MirrorNode {
         ));
     }
 
+    function fetchAccountByPublicKey(string memory publicKey) external override returns (string memory) {
+        return _get(string.concat("accounts?limit=1&account.publickey=", publicKey));
+    }
+
     function fetchTokenRelationshipOfAccount(string memory idOrAliasOrEvmAddress, address token) external override returns (string memory) {
         return _get(string.concat(
             "accounts/",

--- a/src/forwarder/mirror-node-client.js
+++ b/src/forwarder/mirror-node-client.js
@@ -139,6 +139,16 @@ class MirrorNodeClient {
     }
 
     /**
+     * Fetches accounts information by account public key.
+     *
+     * @param {string} publicKey The account public key to fetch.
+     * @returns {Promise<{ accounts: {evm_address: string}[] } | null>} A `Promise` resolving to the account information or `null` if not found.
+     */
+    async getAccountsByPublicKey(publicKey) {
+        return this._get(`accounts?limit=1&account.publickey=${publicKey}`);
+    }
+
+    /**
      * @param {number} blockNumber
      * @returns {Promise<{timestamp: {to: string}} | null>}
      */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -149,6 +149,17 @@ interface IMirrorNodeClient {
         account: string;
         evm_address: string;
     } | null>;
+
+    /**
+     * Get accounts by public key.
+     *
+     * This method should call the Mirror Node API endpoint `GET /api/v1/accounts?limit=1&account.publickey={publicKey}`.
+     *
+     * @param publicKey
+     */
+    getAccountsByPublicKey(publicKey: string): Promise<{
+        accounts: { evm_address: string }[];
+    } | null>;
 }
 
 /**

--- a/test/HTS.t.sol
+++ b/test/HTS.t.sol
@@ -235,8 +235,8 @@ contract HTSTest is Test, TestSetup {
             abi.encode(IHederaTokenService.getTokenInfo.selector),
             abi.encode(HederaResponseCodes.SUCCESS, tokenInfo)
         );
-        vm.expectRevert(bytes("mintToken: invalid account"));
-        IHederaTokenService(HTS_ADDRESS).mintToken(token, amount, metadata);
+        (int64 code, , ) = IHederaTokenService(HTS_ADDRESS).mintToken(token, amount, metadata);
+        assertEq(code, HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY);
     }
 
     function test_mintToken_should_revert_with_invalid_token() external {
@@ -304,8 +304,8 @@ contract HTSTest is Test, TestSetup {
             abi.encode(IHederaTokenService.getTokenInfo.selector),
             abi.encode(HederaResponseCodes.SUCCESS, tokenInfo)
         );
-        vm.expectRevert(bytes("burnToken: invalid account"));
-        IHederaTokenService(HTS_ADDRESS).burnToken(token, amount, serialNumbers);
+        (int64 code, ) = IHederaTokenService(HTS_ADDRESS).burnToken(token, amount, serialNumbers);
+        assertEq(code, HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY);
     }
 
     function test_burnToken_should_revert_with_invalid_token() external {

--- a/test/data/MFCT/getBalanceOfToken_0.0.1841900.json
+++ b/test/data/MFCT/getBalanceOfToken_0.0.1841900.json
@@ -1,0 +1,13 @@
+{
+    "timestamp": "1727813254.582754397",
+    "balances": [
+        {
+            "account": "0.0.2669675",
+            "balance": 5000,
+            "decimals": 0
+        }
+    ],
+    "links": {
+        "next": null
+    }
+}

--- a/test/data/USDC/getBalanceOfToken_0.0.1841900.json
+++ b/test/data/USDC/getBalanceOfToken_0.0.1841900.json
@@ -1,0 +1,13 @@
+{
+    "timestamp": "1724799522.972495003",
+    "balances": [
+        {
+            "account": "0.0.1841900",
+            "balance": 5000000,
+            "decimals": 6
+        }
+    ],
+    "links": {
+        "next": null
+    }
+}

--- a/test/data/getAccountsByPublicKey_0x4e4658983980d1b25a634eeeb26cb2b0f0e2e9c83263ba5b056798d35f2139a8.json
+++ b/test/data/getAccountsByPublicKey_0x4e4658983980d1b25a634eeeb26cb2b0f0e2e9c83263ba5b056798d35f2139a8.json
@@ -1,0 +1,47 @@
+{
+    "accounts": [
+        {
+            "account": "0.0.1841900",
+            "alias": null,
+            "auto_renew_period": 7776000,
+            "balance": {
+                "balance": 4121508670,
+                "timestamp": "1717670177.810816518",
+                "tokens": [
+                    {
+                        "token_id": "0.0.2167043",
+                        "balance": 9.223351547055341e18
+                    },
+                    {
+                        "token_id": "0.0.3739114",
+                        "balance": 0
+                    },
+                    {
+                        "token_id": "0.0.3739115",
+                        "balance": 1
+                    }
+                ]
+            },
+            "created_timestamp": "1706848428.168204434",
+            "decline_reward": false,
+            "deleted": false,
+            "ethereum_nonce": 0,
+            "evm_address": "0x00000000000000000000000000000000001c1aec",
+            "expiry_timestamp": "1714624428.168204434",
+            "key": {
+                "_type": "ED25519",
+                "key": "47ec2d32f5ed2e6d8dd8dac3752268957136e6a6e6ee1f5a2d57c2af4fd4be74"
+            },
+            "max_automatic_token_associations": 0,
+            "memo": "",
+            "pending_reward": 0,
+            "receiver_sig_required": false,
+            "staked_account_id": null,
+            "staked_node_id": null,
+            "stake_period_start": null
+        }
+    ],
+    "links": {
+        "next": "/api/v1/accounts?account.publickey=0x47ec2d32f5ed2e6d8dd8dac3752268957136e6a6e6ee1f5a2d57c2af4fd4be74&limit=1&account.id=gt:0.0.1841900"
+    }
+}

--- a/test/getHtsStorageAt.test.js
+++ b/test/getHtsStorageAt.test.js
@@ -54,6 +54,9 @@ describe('::getHtsStorageAt', function () {
         async getAccount(_idOrAliasOrEvmAddress) {
             throw Error('Not implemented');
         },
+        async getAccountsByPublicKey(_publicKey) {
+            throw Error('Not implemented');
+        },
         async getBalanceOfToken(_tokenId, _accountId) {
             throw Error('Not implemented');
         },

--- a/test/lib/MirrorNodeMock.sol
+++ b/test/lib/MirrorNodeMock.sol
@@ -52,6 +52,11 @@ contract MirrorNodeMock is MirrorNode {
         return vm.readFile(path);
     }
 
+    function fetchAccountByPublicKey(string memory publicKey) external override returns (string memory) {
+        string memory path = string.concat("./test/data/getAccountsByPublicKey_", vm.toLowercase(publicKey), ".json");
+        return vm.readFile(path);
+    }
+
     function fetchTokenRelationshipOfAccount(string memory idOrAliasOrEvmAddress, address token) external override view returns (string memory) {
         string memory symbol = _symbolOf[token];
         string memory path = string.concat("./test/data/", symbol, "/getTokenRelationship_", vm.toLowercase(idOrAliasOrEvmAddress), ".json");

--- a/test/scripts/json-rpc-mock.js
+++ b/test/scripts/json-rpc-mock.js
@@ -112,6 +112,9 @@ const mirrorNodeClient = {
         }
         return requireOrDefault(`getAccount_${idOrAliasOrEvmAddress.toLowerCase()}.json`, null);
     },
+    async getAccountsByPublicKey(publicKey) {
+        return requireOrDefault(`getAccountsByPublicKey_${publicKey.toLowerCase()}.json`, null);
+    },
     async getBalanceOfToken(tokenId, accountId, blockNumber) {
         this.append('getBalanceOfToken', tokenId, accountId, blockNumber);
         const noBalance = { balances: [] };


### PR DESCRIPTION
**Description**:

In order to properly check who is the supplier of the token or perform any operation which depends on these keys we first had to first add the support to the keys itself (find out their evm addresses).

**Related issue(s)**:

Fixes #167

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
