### PR TITLE
feat: nft metada and creation time token uri moved to metadata slot - optional (#198)

### DIFF
--- a/contracts/HtsSystemContract.sol
+++ b/contracts/HtsSystemContract.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+import {decode} from './Base64.sol';
 import {IERC20} from "./IERC20.sol";
 import {IERC721} from "./IERC721.sol";
 import {IHRC719} from "./IHRC719.sol";
@@ -879,12 +880,6 @@ contract HtsSystemContract is IHederaTokenService {
         return bytes32(abi.encodePacked(selector, pad, accountId));
     }
 
-    function _tokenUriSlot(uint32 serialId) internal virtual returns (bytes32) {
-        bytes4 selector = IERC721.tokenURI.selector;
-        uint192 pad = 0x0;
-        return bytes32(abi.encodePacked(selector, pad, serialId));
-    }
-
     function __nftInfoSlot(uint32 serialId) internal virtual returns (bytes32) {
         bytes4 selector = IHederaTokenService.getNonFungibleTokenInfo.selector;
         uint192 pad = 0x0;
@@ -921,11 +916,9 @@ contract HtsSystemContract is IHederaTokenService {
         assembly { amount := sload(slot) }
     }
 
-    function __tokenURI(uint256 serialId) private returns (string memory uri) {
-        bytes32 slot = _tokenUriSlot(uint32(serialId));
-        string storage _uri;
-        assembly { _uri.slot := slot }
-        uri = _uri;
+    function __tokenURI(uint256 serialId) private returns (string memory) {
+        (, bytes memory metadata) = __nftInfo(serialId);
+        return string(decode(string(metadata)));
     }
 
     function __nftInfo(uint256 serialId) private returns (int64, bytes memory) {

--- a/contracts/HtsSystemContractJson.sol
+++ b/contracts/HtsSystemContractJson.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {Vm} from "forge-std/Vm.sol";
-import {decode} from './Base64.sol';
 import {IHederaTokenService} from "./IHederaTokenService.sol";
 import {HtsSystemContract, HTS_ADDRESS} from "./HtsSystemContract.sol";
 import {IERC20} from "./IERC20.sol";
@@ -491,17 +490,6 @@ contract HtsSystemContractJson is HtsSystemContract {
         if (_shouldFetch(slot)) {
             bool associated = mirrorNode().isAssociated(address(this), account);
             _setValue(slot, bytes32(uint256(associated ? 1 : 0)));
-        }
-        return slot;
-    }
-
-    function _tokenUriSlot(uint32 serialId) internal override virtual returns (bytes32) {
-        bytes32 slot = super._tokenUriSlot(serialId);
-        if (_shouldFetch(slot)) {
-            (string memory metadata, ) = mirrorNode().getNftMetadataAndCreatedTimestamp(address(this), serialId);
-            string memory uri = string(decode(metadata));
-            storeString(address(this), uint256(slot), uri);
-            vm.store(_scratchAddr(), slot, bytes32(uint(1)));
         }
         return slot;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -264,6 +264,9 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
         const timestamp = Number(created_timestamp.split('.')[0]).toString(16).padStart(64, '0');
         const metadataEncoded = Buffer.from(metadata, 'utf-8').toString('hex');
         const metadataLength = metadata.length.toString(16).padStart(64, '0');
+
+        // 0x40 represents an offset of 64 bytes (0x40 in hex) within the ABI-encoded data.
+        // It is indicating the start of the bytes content.
         const stringTypeIndicator = '40'.padStart(64, '0');
         const bytes = `${timestamp}${stringTypeIndicator}${metadataLength}${metadataEncoded}`;
         persistentStorage.store(tokenId, blockNumber, nrequestedSlot, bytes);

--- a/src/index.js
+++ b/src/index.js
@@ -266,7 +266,7 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
         const metadataLength = metadata.length.toString(16).padStart(64, '0');
         const stringTypeIndicator = '40'.padStart(64, '0');
         const bytes = `${timestamp}${stringTypeIndicator}${metadataLength}${metadataEncoded}`;
-        persistentStorage.store(tokenId, blockNumber, nrequestedSlot, bytes, 't_bytes_storage');
+        persistentStorage.store(tokenId, blockNumber, nrequestedSlot, bytes);
     }
     let unresolvedValues = persistentStorage.load(tokenId, blockNumber, nrequestedSlot);
     if (unresolvedValues === undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -241,33 +241,6 @@ async function getHtsStorageAt(address, requestedSlot, blockNumber, mirrorNodeCl
         );
     }
 
-    // Encoded `address(tokenId).tokenURI(serialId)` slot
-    // slot(256) = `tokenURI`selector(32) + padding(192) + serialId(32)
-    if (
-        nrequestedSlot >> 32n ===
-        0xc87b56dd_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
-    ) {
-        const serialId = parseInt(requestedSlot.slice(-8), 16);
-        const { metadata } = (await mirrorNodeClient.getNftByTokenIdAndSerial(
-            tokenId,
-            serialId,
-            blockNumber
-        )) ?? {
-            metadata: null,
-        };
-        if (typeof metadata !== 'string')
-            return ret(
-                ZERO_HEX_32_BYTE,
-                `Failed to get the metadata of the NFT ${tokenId}#${serialId}`
-            );
-        persistentStorage.store(
-            tokenId,
-            blockNumber,
-            nrequestedSlot,
-            Buffer.from(metadata, 'base64').toString(),
-            't_string_storage'
-        );
-    }
     // Encoded `address(tokenId).getNonFungibleTokenInfo(token,serialId)` slot
     // slot(256) = `getNonFungibleTokenInfo`selector(32) + padding(192) + serialId(32)
     if (

--- a/src/slotmap.js
+++ b/src/slotmap.js
@@ -339,11 +339,10 @@ class PersistentStorageMap {
      * @param {number} blockNumber
      * @param {bigint} slot
      * @param {Value} value
-     * @param {'t_string_storage' | 't_bytes_storage'} type
      */
-    store(tokenId, blockNumber, slot, value, type) {
+    store(tokenId, blockNumber, slot, value) {
         visit(
-            { label: 'value', slot: slot.toString(), type, offset: 0 },
+            { label: 'value', slot: slot.toString(), type: 't_bytes_storage', offset: 0 },
             0n,
             { value },
             '',

--- a/test/getHtsStorageAt.test.js
+++ b/test/getHtsStorageAt.test.js
@@ -436,7 +436,7 @@ describe('::getHtsStorageAt', function () {
                             spender ? fakeEVMAddress : `0x${toIntHex256(0)}`
                         );
                     });
-                    it(`should get storage for string field \`TokenURI\` for serial id ${serialId}`, async function () {
+                    it.skip(`should get storage for string field \`TokenURI\` for serial id ${serialId}`, async function () {
                         /** @type {IMirrorNodeClient} */
                         const mirrorNodeClient = {
                             ...mirrorNodeClientStub,


### PR DESCRIPTION
**Description**:

Proposition on how we can stop using the token uri slot (since the same, base64 encoded value is already stored as metadata).

**Related issue(s)**:

Fixes #198

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
