### PR TITLE
docs: fix dead link in FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -12,7 +12,7 @@ Enable either the [Foundry library](./README.md#foundry-library) or the [Hardhat
 The reason of error `EvmError: InvalidEFOpcode` is related to how Foundry executes scripts.
 It first runs the script on its local network.
 It records the operations made to be replayed in the remote network.
-See <https://book.getfoundry.sh/tutorials/solidity-scripting#high-level-overview> for more info.
+See <https://book.getfoundry.sh/guides/scripting-with-solidity#overview> for more info.
 Given Foundry's local network does not have a System Contract implementation,
 the error is thrown.
 This is not Hedera specific actually.


### PR DESCRIPTION
**Description**:
Hi! This PR updates a dead link in the FAQ.md file. The outdated link pointing to the old Foundry Solidity scripting tutorial (https://book.getfoundry.sh/tutorials/solidity-scripting#high-level-overview) has been replaced with the correct and updated link (https://book.getfoundry.sh/guides/scripting-with-solidity#overview).

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
