### PR TITLE
docs: fixed typo in "InvalidEFOpcode" error name

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -9,7 +9,7 @@ Enable either the [Foundry library](./README.md#foundry-library) or the [Hardhat
 
 ### What causes the error `EvmError: InvalidFEOpcode`?
 
-The reason of error `EvmError: InvalidEFOpcode` is related to how Foundry executes scripts.
+The reason of error `EvmError: InvalidFEOpcode` is related to how Foundry executes scripts.
 It first runs the script on its local network.
 It records the operations made to be replayed in the remote network.
 See <https://book.getfoundry.sh/guides/scripting-with-solidity#overview> for more info.


### PR DESCRIPTION
**Description**:

<img width="715" alt="Снимок экрана 2025-03-09 в 14 20 39" src="https://github.com/user-attachments/assets/9620b1d9-533b-487c-ad5a-ff0f805f663e" />

I corrected a typo in the error name. It was previously "EvmError: InvalidEFOpcode," and now it's fixed to "EvmError: InvalidFEOpcode" (replacing "EF" with "FE").

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
