### PR TITLE
chore: fix userdoc/devdoc lookup bug

### DIFF
--- a/scripts/abi-table.js
+++ b/scripts/abi-table.js
@@ -45,7 +45,7 @@ function main() {
         ['Function', 'methods'],
         ['Event', 'events'],
     ].forEach(([kind, prop]) => {
-        const members = [...data(kind.toLowerCase(), abi, userdoc[prop] ?? {}, devdoc[prop] ?? {})];
+        const members = [...data(kind.toLowerCase(), abi, userdoc ?? {}, devdoc ?? {})];
         if (members.length > 0) {
             write();
             write(`| ${kind} | Comment |`);


### PR DESCRIPTION
**Description**:

`userdoc[prop]` and `devdoc[prop]` were wrong—`prop` is `"methods"` or `"events"`, but the actual keys are sighashes. This led to missing docs.  

#### **Fix:**  
Pass `userdoc` and `devdoc` directly instead.  

**Before:**  
```js
const members = [...data(kind.toLowerCase(), abi, userdoc[prop] ?? {}, devdoc[prop] ?? {})];
```  

**After:**  
```js
const members = [...data(kind.toLowerCase(), abi, userdoc ?? {}, devdoc ?? {})];
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
