### PR TITLE
fix: incorrect usage of `sighash` for events

### DIFF
--- a/scripts/abi-table.js
+++ b/scripts/abi-table.js
@@ -15,7 +15,7 @@ function* data(kind, abi, userdoc, devdoc) {
     for (const entry of abi) {
         const frag = Fragment.from(entry);
         if (frag.type === kind) {
-            const sighash = frag.format('sighash');
+            const sighash = kind === 'function' ? frag.format('sighash') : frag.format('topicHash');
             const [member] = frag.format('full').replace(`${kind} `, '').split(' returns ');
             const notice = (userdoc[sighash]?.notice ?? '').trim();
             const dev = (devdoc[sighash]?.details ?? '').trim();


### PR DESCRIPTION
**Description**:

`sighash` was being applied to events, which isn’t correct—events use `topicHash` instead.
This update ensures that functions use `sighash`, while events correctly use `topicHash`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
