### PR TITLE
feat: hedera local node to solo migration (#303)

### DIFF
--- a/.github/actions/setup-solo-stack/action.yml
+++ b/.github/actions/setup-solo-stack/action.yml
@@ -87,7 +87,7 @@ runs:
                 --namespace "$solo_ns" \
                 --external-address "$EXTERNAL_ADDRESS"
 
-        - name: Forward consensus compatibility port
+        - name: Forward compatibility ports
           shell: bash
           env:
               SOLO_NS: ${{ steps.solo_deploy.outputs.namespace }}
@@ -95,19 +95,17 @@ runs:
               set -euo pipefail
 
               kubectl -n "$SOLO_NS" get svc haproxy-node1-svc
-              kubectl -n "$SOLO_NS" port-forward svc/haproxy-node1-svc 50211:50211 >/tmp/solo-consensus-port-forward.log 2>&1 &
+              kubectl -n "$SOLO_NS" port-forward svc/haproxy-node1-svc 50211:50211 &
+              echo "Forwarding svc/haproxy-node1-svc -> localhost:50211 (consensus gRPC)"
 
-              for i in $(seq 1 30); do
-                if nc -z 127.0.0.1 50211; then
-                  exit 0
-                fi
-                echo "Attempt ${i}/30: consensus gRPC compatibility port is not ready, retrying in 2s..."
-                sleep 2
-              done
+              if kubectl -n "$SOLO_NS" get svc mirror-1-web3 &>/dev/null; then
+                kubectl -n "$SOLO_NS" port-forward svc/mirror-1-web3 8545:80 &
+                echo "Forwarding svc/mirror-1-web3 -> localhost:8545 (mirror Web3)"
+              else
+                echo "::warning::svc/mirror-1-web3 not found in $SOLO_NS; skipping 8545 forward"
+              fi
 
-              echo "ERROR: consensus gRPC compatibility port did not become available."
-              cat /tmp/solo-consensus-port-forward.log
-              exit 1
+              sleep 3
 
         - name: Verify Mirror REST API
           shell: bash

--- a/.github/actions/setup-solo-stack/action.yml
+++ b/.github/actions/setup-solo-stack/action.yml
@@ -1,0 +1,158 @@
+name: Setup Solo Stack
+description: Deploy a Solo Falcon stack for local Hedera network tests.
+
+inputs:
+    solo-version:
+        description: Solo CLI version used for Falcon deploy.
+        required: false
+        default: '0.72.0'
+    network-tag:
+        description: Optional consensus node release tag.
+        required: false
+        # Blank by default so the pinned Solo CLI version controls its bundled
+        # consensus node version unless a workflow explicitly overrides it.
+        default: ''
+    mirror-tag:
+        description: Optional mirror node release tag.
+        required: false
+        # Blank by default so the pinned Solo CLI version controls its bundled
+        # mirror node version unless a workflow explicitly overrides it.
+        default: ''
+    relay-tag:
+        description: Optional JSON-RPC relay release tag.
+        required: false
+        # Blank by default so the pinned Solo CLI version controls its bundled
+        # relay version unless a workflow explicitly overrides it.
+        default: ''
+    external-address:
+        description: Bind address for Solo kubectl port-forwards.
+        required: false
+        default: '127.0.0.1'
+
+outputs:
+    deployment_name:
+        description: Solo deployment name.
+        value: ${{ steps.solo_deploy.outputs.deployment_name }}
+    namespace:
+        description: Kubernetes namespace used by the Solo deployment.
+        value: ${{ steps.solo_deploy.outputs.namespace }}
+
+runs:
+    using: composite
+    steps:
+        - name: Generate Falcon values
+          shell: bash
+          env:
+              NETWORK_TAG: ${{ inputs.network-tag }}
+              MIRROR_TAG: ${{ inputs.mirror-tag }}
+              RELAY_TAG: ${{ inputs.relay-tag }}
+          run: |
+              set -euo pipefail
+
+              falcon_values=".github/falcon.yml"
+              : > "$falcon_values"
+
+              if [ -n "$NETWORK_TAG" ]; then
+                {
+                  echo "network:"
+                  echo "  --release-tag: \"$NETWORK_TAG\""
+                  echo "setup:"
+                  echo "  --release-tag: \"$NETWORK_TAG\""
+                } >> "$falcon_values"
+              fi
+
+              {
+                echo "consensusNode:"
+                echo "  --force-port-forward: true"
+                echo "  --node-aliases: \"node1\""
+                echo "mirrorNode:"
+                echo "  --enable-ingress: true"
+                echo "  --pinger: true"
+                echo "  --values-file: .github/mirror-node-values.yaml"
+                echo "  --force-port-forward: true"
+              } >> "$falcon_values"
+
+              if [ -n "$MIRROR_TAG" ]; then
+                echo "  --mirror-node-version: \"$MIRROR_TAG\"" >> "$falcon_values"
+              fi
+
+              {
+                echo "relayNode:"
+                echo "  --node-aliases: \"node1\""
+                echo "  --force-port-forward: true"
+              } >> "$falcon_values"
+
+              if [ -n "$RELAY_TAG" ]; then
+                echo "  --relay-release: \"$RELAY_TAG\"" >> "$falcon_values"
+              fi
+
+        - name: Setup Kind
+          uses: helm/kind-action@v1.12.0
+          with:
+              install_only: true
+              wait: 120s
+
+        - name: Start Solo stack
+          id: solo_deploy
+          shell: bash
+          env:
+              SOLO_VERSION: ${{ inputs.solo-version }}
+              EXTERNAL_ADDRESS: ${{ inputs.external-address }}
+          run: |
+              set -euo pipefail
+
+              ns_base="sc-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+              solo_ns="$(echo "$ns_base" | tr '[:upper:]_' '[:lower:]-' | cut -c1-63)"
+              solo_deployment="$solo_ns"
+
+              echo "deployment_name=$solo_deployment" >> "$GITHUB_OUTPUT"
+              echo "namespace=$solo_ns" >> "$GITHUB_OUTPUT"
+
+              npx "@hashgraph/solo@$SOLO_VERSION" one-shot falcon deploy \
+                --values-file .github/falcon.yml \
+                --dev \
+                --deploy-explorer=false \
+                --deployment "$solo_deployment" \
+                --namespace "$solo_ns" \
+                --external-address "$EXTERNAL_ADDRESS"
+
+        - name: Forward consensus compatibility port
+          shell: bash
+          env:
+              SOLO_NS: ${{ steps.solo_deploy.outputs.namespace }}
+          run: |
+              set -euo pipefail
+
+              kubectl -n "$SOLO_NS" get svc haproxy-node1-svc
+              kubectl -n "$SOLO_NS" port-forward svc/haproxy-node1-svc 50211:50211 >/tmp/solo-consensus-port-forward.log 2>&1 &
+
+              for i in $(seq 1 30); do
+                if nc -z 127.0.0.1 50211; then
+                  exit 0
+                fi
+                echo "Attempt ${i}/30: consensus gRPC compatibility port is not ready, retrying in 2s..."
+                sleep 2
+              done
+
+              echo "ERROR: consensus gRPC compatibility port did not become available."
+              cat /tmp/solo-consensus-port-forward.log
+              exit 1
+
+        - name: Verify Mirror REST API
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              echo "Waiting for mirror node REST API..."
+              for i in $(seq 1 30); do
+                response=$(curl -sf http://localhost:38081/api/v1/accounts 2>/dev/null || true)
+                if echo "$response" | grep -q '"accounts"'; then
+                  echo "Mirror REST API is up."
+                  exit 0
+                fi
+                echo "Attempt ${i}/30: not ready, retrying in 10s..."
+                sleep 10
+              done
+
+              echo "ERROR: Mirror REST API did not become available."
+              exit 1

--- a/.github/actions/setup-solo-stack/action.yml
+++ b/.github/actions/setup-solo-stack/action.yml
@@ -7,23 +7,17 @@ inputs:
         required: false
         default: '0.72.0'
     network-tag:
-        description: Optional consensus node release tag.
+        description: Consensus / network node container image tag (--release-tag).
         required: false
-        # Blank by default so the pinned Solo CLI version controls its bundled
-        # consensus node version unless a workflow explicitly overrides it.
-        default: ''
+        default: 'v0.72.0'
     mirror-tag:
-        description: Optional mirror node release tag.
+        description: Mirror node chart/image version (--mirror-node-version).
         required: false
-        # Blank by default so the pinned Solo CLI version controls its bundled
-        # mirror node version unless a workflow explicitly overrides it.
-        default: ''
+        default: 'v0.151.0'
     relay-tag:
-        description: Optional JSON-RPC relay release tag.
+        description: JSON-RPC relay image/chart tag (--relay-release).
         required: false
-        # Blank by default so the pinned Solo CLI version controls its bundled
-        # relay version unless a workflow explicitly overrides it.
-        default: ''
+        default: '0.76.2'
     external-address:
         description: Bind address for Solo kubectl port-forwards.
         required: false
@@ -40,51 +34,28 @@ outputs:
 runs:
     using: composite
     steps:
-        - name: Generate Falcon values
+        - name: Generate falcon-values config file
           shell: bash
-          env:
-              NETWORK_TAG: ${{ inputs.network-tag }}
-              MIRROR_TAG: ${{ inputs.mirror-tag }}
-              RELAY_TAG: ${{ inputs.relay-tag }}
           run: |
-              set -euo pipefail
-
-              falcon_values=".github/falcon.yml"
-              : > "$falcon_values"
-
-              if [ -n "$NETWORK_TAG" ]; then
-                {
-                  echo "network:"
-                  echo "  --release-tag: \"$NETWORK_TAG\""
-                  echo "setup:"
-                  echo "  --release-tag: \"$NETWORK_TAG\""
-                } >> "$falcon_values"
-              fi
-
-              {
-                echo "consensusNode:"
-                echo "  --force-port-forward: true"
-                echo "  --node-aliases: \"node1\""
-                echo "mirrorNode:"
-                echo "  --enable-ingress: true"
-                echo "  --pinger: true"
-                echo "  --values-file: .github/mirror-node-values.yaml"
-                echo "  --force-port-forward: true"
-              } >> "$falcon_values"
-
-              if [ -n "$MIRROR_TAG" ]; then
-                echo "  --mirror-node-version: \"$MIRROR_TAG\"" >> "$falcon_values"
-              fi
-
-              {
-                echo "relayNode:"
-                echo "  --node-aliases: \"node1\""
-                echo "  --force-port-forward: true"
-              } >> "$falcon_values"
-
-              if [ -n "$RELAY_TAG" ]; then
-                echo "  --relay-release: \"$RELAY_TAG\"" >> "$falcon_values"
-              fi
+              cat > .github/falcon.yml <<EOF
+              network:
+                --release-tag: "${{ inputs.network-tag }}"
+              setup:
+                --release-tag: "${{ inputs.network-tag }}"
+              consensusNode:
+                --force-port-forward: true
+                --node-aliases: "node1"
+              mirrorNode:
+                --enable-ingress: true
+                --pinger: true
+                --mirror-node-version: "${{ inputs.mirror-tag }}"
+                --values-file: .github/mirror-node-values.yaml
+                --force-port-forward: true
+              relayNode:
+                --relay-release: "${{ inputs.relay-tag }}"
+                --node-aliases: "node1"
+                --force-port-forward: true
+              EOF
 
         - name: Setup Kind
           uses: helm/kind-action@v1.12.0

--- a/.github/mirror-node-values.yaml
+++ b/.github/mirror-node-values.yaml
@@ -1,0 +1,5 @@
+# Solo mirror Helm values used by CI local-network tests.
+web3:
+    env:
+        HIERO_MIRROR_WEB3_OPCODE_TRACER_ENABLED: 'true'
+        HIERO_MIRROR_WEB3_EVM_NETWORK: 'OTHER'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
+  SOLO_VERSION: 0.72.0
 
   # This enables colored output for tests run by `mocha`.
   # `FORCE_COLOR` is used by `chalk`, which is used internally by `mocha`.
@@ -380,7 +381,7 @@ jobs:
         working-directory: examples/hardhat-hts
 
   foundry-example-scripts:
-    name: Foundry example scripts w/local node
+    name: Foundry example scripts w/Solo
     runs-on: smart-contracts-linux-medium
     steps:
       - name: Harden Runner
@@ -409,22 +410,23 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Start the local node
-        run: npx hedera start --detach --verbose=trace
-        timeout-minutes: 5
+      - name: Set up Solo stack
+        id: solo_stack
+        uses: ./.github/actions/setup-solo-stack
+        with:
+          solo-version: ${{ env.SOLO_VERSION }}
 
       - name: Run Forge build on Foundry HTS example
         run: forge build
         working-directory: examples/foundry-hts
 
-      # Uses a local node's account private key
-      # https://github.com/hiero-ledger/hiero-local-node?tab=readme-ov-file#hedera-start-options
-      - name: Set up Local Node's account Private Key
+      # Uses a Solo dev account private key.
+      - name: Set up Solo account private key
         run: echo "PRIVATE_KEY=0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524" > .env
         working-directory: examples/foundry-hts
 
-      - name: Run Foundry script on local node
-        run: forge script script/CreateToken.s.sol -vvv --rpc-url localnode --skip-simulation --broadcast
+      - name: Run Foundry script on Solo
+        run: forge script script/CreateToken.s.sol -vvv --rpc-url solo --skip-simulation --broadcast
         working-directory: examples/foundry-hts
 
       # https://book.getfoundry.sh/guides/scripting-with-solidity
@@ -432,14 +434,26 @@ jobs:
         run: |
           TOKEN_ADDR=`cat broadcast/CreateToken.s.sol/298/run-latest.json | jq '.receipts[0].contractAddress' --raw-output`
           echo "Token Address: $TOKEN_ADDR"
-          TOKEN_CODE=`cast code --rpc-url localnode $TOKEN_ADDR`
+          TOKEN_CODE=`cast code --rpc-url solo $TOKEN_ADDR`
           echo "Token Code: $TOKEN_CODE"
           test $TOKEN_CODE != "0x"
         working-directory: examples/foundry-hts
 
-      - name: Stop the local node
-        if: ${{ !cancelled() }}
-        run: npx hedera stop
+      - name: Destroy Solo stack
+        if: always()
+        run: |
+          npx @hashgraph/solo@${{ env.SOLO_VERSION }} one-shot falcon destroy \
+            --deployment "${{ steps.solo_stack.outputs.deployment_name }}" \
+            --dev \
+            --quiet-mode || true
+
+      - name: Upload Solo logs
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: solo-logs-${{ github.job }}
+          path: ~/.solo/logs/*
+          if-no-files-found: warn
 
   e2e-test:
     name: 'NPM e2e validation tests'
@@ -471,16 +485,30 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Start the local node
-        run: npx hedera start -d --verbose=trace
-        timeout-minutes: 5
+      - name: Set up Solo stack
+        id: solo_stack
+        uses: ./.github/actions/setup-solo-stack
+        with:
+          solo-version: ${{ env.SOLO_VERSION }}
 
       - name: Run e2e Validation Tests
         run: npm run test:e2e
 
-      - name: Stop the local node
-        if: ${{ !cancelled() }}
-        run: npx hedera stop
+      - name: Destroy Solo stack
+        if: always()
+        run: |
+          npx @hashgraph/solo@${{ env.SOLO_VERSION }} one-shot falcon destroy \
+            --deployment "${{ steps.solo_stack.outputs.deployment_name }}" \
+            --dev \
+            --quiet-mode || true
+
+      - name: Upload Solo logs
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: solo-logs-${{ github.job }}
+          path: ~/.solo/logs/*
+          if-no-files-found: warn
 
   slither-analysis:
     name: 'Slither static code analysis'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,7 +381,7 @@ jobs:
         working-directory: examples/hardhat-hts
 
   foundry-example-scripts:
-    name: Foundry example scripts w/Solo
+    name: Foundry example scripts with Solo
     runs-on: smart-contracts-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -411,7 +411,7 @@ jobs:
         run: npm ci
 
       - name: Set up Solo stack
-        id: solo_stack
+        id: solo_stack_foundry_example
         uses: ./.github/actions/setup-solo-stack
         with:
           solo-version: ${{ env.SOLO_VERSION }}
@@ -486,7 +486,7 @@ jobs:
         run: npm ci
 
       - name: Set up Solo stack
-        id: solo_stack
+        id: solo_stack_e2e
         uses: ./.github/actions/setup-solo-stack
         with:
           solo-version: ${{ env.SOLO_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -411,10 +411,31 @@ jobs:
         run: npm ci
 
       - name: Set up Solo stack
-        id: solo_stack_foundry_example
+        id: solo_stack
         uses: ./.github/actions/setup-solo-stack
         with:
           solo-version: ${{ env.SOLO_VERSION }}
+
+      - name: Diagnose Solo relay failure
+        if: failure() && steps.solo_stack.outcome == 'failure'
+        env:
+          SOLO_NS: ${{ steps.solo_stack.outputs.namespace }}
+        run: |
+          set +e
+
+          if [ -z "${SOLO_NS:-}" ]; then
+            ns_base="sc-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+            SOLO_NS="$(echo "$ns_base" | tr '[:upper:]_' '[:lower:]-' | cut -c1-63)"
+          fi
+
+          echo "Diagnosing Solo relay failure in namespace: $SOLO_NS"
+          kubectl config current-context || true
+          kubectl get namespace "$SOLO_NS" -o wide || true
+          kubectl -n "$SOLO_NS" get all -o wide || true
+          kubectl -n "$SOLO_NS" get pods -o wide --show-labels || true
+          kubectl -n "$SOLO_NS" get events --sort-by='.lastTimestamp' || true
+          kubectl -n "$SOLO_NS" describe deploy,rs,pod,svc -l app.kubernetes.io/instance=relay-1 || true
+          kubectl -n "$SOLO_NS" logs -l app.kubernetes.io/instance=relay-1 --all-containers --tail=200 --prefix || true
 
       - name: Run Forge build on Foundry HTS example
         run: forge build
@@ -486,7 +507,7 @@ jobs:
         run: npm ci
 
       - name: Set up Solo stack
-        id: solo_stack_e2e
+        id: solo_stack
         uses: ./.github/actions/setup-solo-stack
         with:
           solo-version: ${{ env.SOLO_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,7 +380,7 @@ jobs:
         run: npm run test
         working-directory: examples/hardhat-hts
 
-  foundry-example-scripts:
+  foundry-examples:
     name: Foundry example scripts with Solo
     runs-on: smart-contracts-linux-medium
     steps:
@@ -415,27 +415,6 @@ jobs:
         uses: ./.github/actions/setup-solo-stack
         with:
           solo-version: ${{ env.SOLO_VERSION }}
-
-      - name: Diagnose Solo relay failure
-        if: failure() && steps.solo_stack.outcome == 'failure'
-        env:
-          SOLO_NS: ${{ steps.solo_stack.outputs.namespace }}
-        run: |
-          set +e
-
-          if [ -z "${SOLO_NS:-}" ]; then
-            ns_base="sc-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
-            SOLO_NS="$(echo "$ns_base" | tr '[:upper:]_' '[:lower:]-' | cut -c1-63)"
-          fi
-
-          echo "Diagnosing Solo relay failure in namespace: $SOLO_NS"
-          kubectl config current-context || true
-          kubectl get namespace "$SOLO_NS" -o wide || true
-          kubectl -n "$SOLO_NS" get all -o wide || true
-          kubectl -n "$SOLO_NS" get pods -o wide --show-labels || true
-          kubectl -n "$SOLO_NS" get events --sort-by='.lastTimestamp' || true
-          kubectl -n "$SOLO_NS" describe deploy,rs,pod,svc -l app.kubernetes.io/instance=relay-1 || true
-          kubectl -n "$SOLO_NS" logs -l app.kubernetes.io/instance=relay-1 --all-containers --tail=200 --prefix || true
 
       - name: Run Forge build on Foundry HTS example
         run: forge build

--- a/CREATE_TOKEN.md
+++ b/CREATE_TOKEN.md
@@ -109,7 +109,7 @@ A successful call to any token creation method should have the following effect
 HTS emulation should keep an internal counter to track the next token address to be created.
 
 - **In forking mode,** this counter should resemble the next token address from the remote network. This can be obtained by querying the Mirror Node for the latest account and token IDs and getting the latest (higher) between these two. The latest account ID can be obtained with `/v1/accounts?order=desc&limit=1`. On the other hand, the latest token ID can be obtained with `/v1/tokens?order=desc&limit=1`.
-- **In non-forking mode,** this counter should be `0.0.1032`, the first token account ID created by local node when `--createInitialResources=true` is specified.
+- **In non-forking mode,** this counter should be `0.0.1012`, the first token account ID created after Solo initializes its predefined alias accounts.
 
 ### Delete Token
 

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -121,7 +121,7 @@ It would save a lot of time for Hedera developers to have the ability to use for
 
 In the following, _Development fork_ refers to the Ethereum Development Environment used to simulate EVM state locally, _e.g._, Ganache, Hardhat's EDR or Foundry's Anvil.
 _Remote network_ refers to the Hedera network to pull EVM bytecode and state from.
-It can be either `mainnet`, `testnet`, `previewnet` or any local network, like local-node or solo.
+It can be either `mainnet`, `testnet`, `previewnet` or a local Solo network.
 
 We need to enable fork testing when any of the Hedera Services, _e.g._, Hedera Token Service, are involved.
 
@@ -155,7 +155,7 @@ In a nutshell, this bytecode does not have any state and redirects all incoming 
 ### Constraints
 
 - Code returned for HTS Tokens should **not** be changed. This will allow us to use the same mechanism and state for existing tokens in the remote network, or newly created tokens in the local network.
-- Avoid the need for developers to initiate extra processes, _e.g._, start `local-node` to enable forking.
+- Avoid the need for developers to initiate extra processes, _e.g._, start Solo to enable forking.
 - Storage slots need to be consistent with existing tooling. For example, Foundry supports the `deal` cheatcode <https://book.getfoundry.sh/reference/forge-std/deal>, which allows users to change the balance of _any_ ERC20 token. Our forking support should be compatible with this use case.
 
   ```solidity

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ For example
 mainnet = "https://mainnet.hashio.io/api"
 testnet = "https://testnet.hashio.io/api"
 previewnet = "https://previewnet.hashio.io/api"
-localnode = "http://localhost:7546"
+solo = "http://localhost:37546"
 ```
 
 > [!IMPORTANT]
@@ -686,7 +686,7 @@ cat test/scripts/curl.log
 These Solidity tests are used to test both the `HtsSystemContract` and the `npm` package.
 It is the implementation used by Hardhat users.
 
-Instead of starting a `local-node` or using a remote network,
+Instead of starting Solo or using a remote network,
 they use the [`json-rpc-mock.js`](./test/scripts/json-rpc-mock.js) script as a backend without the need for any additional services,
 thus making the tests more robust.
 This is the network Foundry's Anvil is forking from.
@@ -712,9 +712,9 @@ forge test --fork-url http://localhost:7546 --no-storage-caching
 
 The goal of this test is to validate that our HTS emulation matches the behavior of the real HTS (provided by Hedera Services).
 The test works as follow.
-It first creates an HTS token on a Local Node.
-Then, it proceeds to start a local network (Foundry's Anvil) forked from the Local Node after token creation.
-The same test cases are executed on both networks, first on Anvil, and then on Local Node, where they yield the same result.
+It first creates an HTS token on a Solo network.
+Then, it proceeds to start a local network (Foundry's Anvil) forked from Solo after token creation.
+The same test cases are executed on both networks, first on Anvil, and then on Solo, where they yield the same result.
 
 > [!NOTE]
 > The test sets the `DEBUG_DISABLE_BALANCE_BLOCKNUMBER` environment variable used by the Mirror Node client.
@@ -723,21 +723,27 @@ The same test cases are executed on both networks, first on Anvil, and then on L
 > This in turn fetches the correct balance in the case where the Mirror Node did not get the latest balance snapshot from the Consensus Node.
 > This simplifies the validation tests considerably, and allows to compare behavior of real HTS and emulated HTS more easily.
 
-You need a Local Node running in order to execute this test.
-See [Hedera Local Node, _&sect; Requirements_](https://github.com/hashgraph/hedera-local-node?tab=readme-ov-file#requirements) for tools needed to run it.
-To do so, run the following
+You need a Solo network running in order to execute this test.
+Install [Kind](https://kind.sigs.k8s.io/) and `kubectl`, then deploy Solo with
 
 ```console
-npm run hedera:start
+npm run solo:deploy -- --deployment hedera-forking --namespace hedera-forking
 ```
 
-> Alternatively, once you are done with this test, you can stop the Local Node using
+Solo exposes JSON-RPC relay at `http://localhost:37546` and Mirror REST at `http://localhost:38081/api/v1/`.
+The e2e test also uses a compatibility consensus gRPC port for the Hedera SDK; expose it with
+
+```console
+kubectl -n hedera-forking port-forward svc/haproxy-node1-svc 50211:50211
+```
+
+> Alternatively, once you are done with this test, you can stop Solo using
 >
 > ```console
-> npm run hedera:stop
+> npm run solo:destroy -- --deployment hedera-forking --quiet-mode
 > ```
 
-Once Local Node is up and running, run the validation tests with
+Once Solo is up and running, run the validation tests with
 
 ```console
 npm run test:e2e

--- a/contracts/MirrorNodeFFI.sol
+++ b/contracts/MirrorNodeFFI.sol
@@ -145,9 +145,9 @@ contract MirrorNodeFFI is MirrorNode {
         } else if (block.chainid == 297) {
             url = "https://previewnet.mirrornode.hedera.com/api/v1/";
         } else if (block.chainid == 298) {
-            url = "http://localhost:5551/api/v1/";
+            url = "http://localhost:38081/api/v1/";
         } else {
-            revert("The provided chain ID is not supported by the Hedera Mirror Node library. Please use one of the supported chain IDs: 295, 296, or 297.");
+            revert("The provided chain ID is not supported by the Hedera Mirror Node library. Please use one of the supported chain IDs: 295, 296, 297, or 298.");
         }
     }
 }

--- a/examples/foundry-hts/foundry.toml
+++ b/examples/foundry-hts/foundry.toml
@@ -12,4 +12,4 @@ ffi = true
 mainnet = "https://mainnet.hashio.io/api"
 testnet = "https://testnet.hashio.io/api"
 previewnet = "https://previewnet.hashio.io/api"
-localnode = "http://localhost:7546"
+solo = "http://localhost:37546"

--- a/foundry.toml
+++ b/foundry.toml
@@ -29,3 +29,5 @@ fs_permissions = [
 ]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+
+[profile.ci]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.13.0",
-                "@hashgraph/hedera-local": "2.32.6",
                 "@hashgraph/sdk": "^2.55.1",
                 "@nomicfoundation/ethereumjs-util": "^9.0.4",
                 "@nomicfoundation/hardhat-chai-matchers": "2.0.8",
@@ -23,6 +22,7 @@
                 "@types/chai": "^4.3.20",
                 "@types/mocha": "^10.0.7",
                 "@types/sinon": "^17.0.3",
+                "ansi-colors": "^4.1.3",
                 "c8": "^10.1.3",
                 "chai": "^4.0.0",
                 "eslint": "^9.13.0",
@@ -589,13 +589,6 @@
             "engines": {
                 "node": ">=6.9.0"
             }
-        },
-        "node_modules/@balena/dockerignore": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-            "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
-            "dev": true,
-            "license": "Apache-2.0"
         },
         "node_modules/@bcoe/v8-coverage": {
             "version": "1.0.2",
@@ -1237,30 +1230,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@hashgraph/hedera-local": {
-            "version": "2.32.6",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.32.6.tgz",
-            "integrity": "sha512-SzRIFMFLDZ8P5jhzVb51+hMz4yKky7GZgkhOxeCAC1vWQQTp6PE6H56g3Gg/o6vefDcIRytwhlj/dvC3ZgMZLA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@hashgraph/sdk": "^2.49.2",
-                "csv-parser": "^3.0.0",
-                "detect-port": "^1.6.1",
-                "dockerode": "^4.0.2",
-                "dotenv": "^16.4.5",
-                "ethers": "^6.13.2",
-                "js-yaml": "^4.1.0",
-                "rimraf": "^6.0.1",
-                "semver": "^7.6.3",
-                "shelljs": "^0.8.5",
-                "ts-mocha": "^10.0.0",
-                "yargs": "^17.7.2"
-            },
-            "bin": {
-                "hedera": "build/index.js"
-            }
-        },
         "node_modules/@hashgraph/sdk": {
             "version": "2.80.0",
             "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.80.0.tgz",
@@ -1416,29 +1385,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
-            }
-        },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -2934,14 +2880,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/json5": {
-            "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@types/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3421,16 +3359,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/address": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-            "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/adm-zip": {
             "version": "0.4.16",
             "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
@@ -3587,16 +3515,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
-        "node_modules/arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3604,16 +3522,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
         },
         "node_modules/asn1js": {
             "version": "3.0.6",
@@ -3866,23 +3774,6 @@
                 "baseline-browser-mapping": "dist/cli.js"
             }
         },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
-        "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "dev": true,
-            "license": "Unlicense"
-        },
         "node_modules/bignumber.js": {
             "version": "9.1.1",
             "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
@@ -3903,43 +3794,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/bl/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
             }
         },
         "node_modules/blakejs": {
@@ -4135,23 +3989,14 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/buffer-xor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
             "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
             "license": "MIT"
-        },
-        "node_modules/buildcheck": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
-            "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/bytes": {
             "version": "3.1.2",
@@ -4379,13 +4224,6 @@
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
-        },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/chrome-launcher": {
             "version": "0.15.2",
@@ -4712,21 +4550,6 @@
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "license": "MIT"
         },
-        "node_modules/cpu-features": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
-            "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "dependencies": {
-                "buildcheck": "~0.0.6",
-                "nan": "^2.19.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/create-hash": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -4783,19 +4606,6 @@
             "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/csv-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.0.tgz",
-            "integrity": "sha512-fgKbp+AJbn1h2dcAHKIdKNSSjfp43BZZykXsCjzALjKy80VXQNHPFJ6T9Afwdzoj24aMkq8GwDS7KGcDPpejrA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "csv-parser": "bin/csv-parser"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
         },
         "node_modules/dateformat": {
             "version": "4.6.3",
@@ -4895,24 +4705,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/detect-port": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
-            "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "address": "^1.0.1",
-                "debug": "4"
-            },
-            "bin": {
-                "detect": "bin/detect-port.js",
-                "detect-port": "bin/detect-port.js"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/diff": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -4920,54 +4712,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/docker-modem": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
-            "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "readable-stream": "^3.5.0",
-                "split-ca": "^1.0.1",
-                "ssh2": "^1.15.0"
-            },
-            "engines": {
-                "node": ">= 8.0"
-            }
-        },
-        "node_modules/dockerode": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
-            "integrity": "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@balena/dockerignore": "^1.0.2",
-                "@grpc/grpc-js": "^1.11.1",
-                "@grpc/proto-loader": "^0.7.13",
-                "docker-modem": "^5.0.6",
-                "protobufjs": "^7.3.2",
-                "tar-fs": "^2.1.4",
-                "uuid": "^10.0.0"
-            },
-            "engines": {
-                "node": ">= 8.0"
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {
@@ -5951,13 +5695,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/fs-extra": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -6743,16 +6480,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
-        },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
         },
         "node_modules/invariant": {
             "version": "2.2.4",
@@ -7790,8 +7517,9 @@
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "devOptional": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true,
+            "peer": true
         },
         "node_modules/makeerror": {
             "version": "1.0.12",
@@ -8340,13 +8068,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mnemonist": {
             "version": "0.38.5",
             "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
@@ -8540,14 +8261,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
-        },
-        "node_modules/nan": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-            "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -8872,6 +8585,7 @@
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8890,34 +8604,8 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
-        "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.2.4",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/pathval": {
             "version": "1.1.1",
@@ -9524,18 +9212,6 @@
                 "node": ">= 12.13.0"
             }
         },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dev": true,
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/regenerator-runtime": {
             "version": "0.13.11",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -9568,6 +9244,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
             "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "path-parse": "^1.0.6"
             },
@@ -9631,60 +9308,6 @@
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/rimraf": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
-            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "glob": "^13.0.0",
-                "package-json-from-dist": "^1.0.1"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/glob": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/minimatch": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/ripemd160": {
             "version": "2.0.3",
@@ -9753,7 +9376,8 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/scheduler": {
             "version": "0.27.0",
@@ -10015,46 +9639,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/shelljs/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10202,6 +9786,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -10212,6 +9797,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10222,13 +9808,6 @@
             "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
             "dev": true,
             "license": "(WTFPL OR MIT)"
-        },
-        "node_modules/split-ca": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-            "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/split2": {
             "version": "4.2.0",
@@ -10247,24 +9826,6 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "peer": true
-        },
-        "node_modules/ssh2": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
-            "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "asn1": "^0.2.6",
-                "bcrypt-pbkdf": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=10.16.0"
-            },
-            "optionalDependencies": {
-                "cpu-features": "~0.0.10",
-                "nan": "^2.23.0"
-            }
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",
@@ -10484,17 +10045,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/strip-final-newline": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -10544,36 +10094,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/terser": {
@@ -10823,84 +10343,6 @@
                 "typescript": ">=4.8.4"
             }
         },
-        "node_modules/ts-mocha": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.1.0.tgz",
-            "integrity": "sha512-T0C0Xm3/WqCuF2tpa0GNGESTBoKZaiqdUP8guNv4ZY316AFXlyidnrzQ1LUrCT0Wb1i3J0zFTgOh/55Un44WdA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ts-node": "7.0.1"
-            },
-            "bin": {
-                "ts-mocha": "bin/ts-mocha"
-            },
-            "engines": {
-                "node": ">= 6.X.X"
-            },
-            "optionalDependencies": {
-                "tsconfig-paths": "^3.5.0"
-            },
-            "peerDependencies": {
-                "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X || ^11.X.X"
-            }
-        },
-        "node_modules/ts-mocha/node_modules/diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/ts-mocha/node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/ts-mocha/node_modules/ts-node": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "arrify": "^1.0.0",
-                "buffer-from": "^1.1.0",
-                "diff": "^3.1.0",
-                "make-error": "^1.1.1",
-                "minimist": "^1.2.0",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.5.6",
-                "yn": "^2.0.0"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
-        "node_modules/ts-mocha/node_modules/yn": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-            "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/ts-node": {
             "version": "10.9.2",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -10955,34 +10397,6 @@
             "peer": true,
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/tsconfig-paths": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-            "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/json5": "^0.0.29",
-                "json5": "^1.0.2",
-                "minimist": "^1.2.6",
-                "strip-bom": "^3.0.0"
-            }
-        },
-        "node_modules/tsconfig-paths/node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
             }
         },
         "node_modules/tslib": {
@@ -11203,20 +10617,6 @@
             "peer": true,
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.13.0",
-        "@hashgraph/hedera-local": "2.32.6",
         "@hashgraph/sdk": "^2.55.1",
         "@nomicfoundation/ethereumjs-util": "^9.0.4",
         "@nomicfoundation/hardhat-chai-matchers": "2.0.8",
@@ -48,6 +47,7 @@
         "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.7",
         "@types/sinon": "^17.0.3",
+        "ansi-colors": "^4.1.3",
         "c8": "^10.1.3",
         "chai": "^4.0.0",
         "eslint": "^9.13.0",
@@ -70,7 +70,7 @@
         "coverage": "c8 mocha",
         "test:e2e": "mocha test/*.e2e.js --fgrep ::e2e",
         "make:readme": "scripts/readme.js README.md",
-        "hedera:start": "hedera start",
-        "hedera:stop": "hedera stop"
+        "solo:deploy": "npx @hashgraph/solo@0.72.0 one-shot falcon deploy --dev --deploy-explorer=false --external-address 127.0.0.1",
+        "solo:destroy": "npx @hashgraph/solo@0.72.0 one-shot falcon destroy --dev"
     }
 }

--- a/scripts/create-token.js
+++ b/scripts/create-token.js
@@ -22,7 +22,7 @@ async function main() {
 
     // Create your Hedera Testnet client and set the operator
     const client = Client.forTestnet();
-    // Uncomment the following to create the token in a Local Network
+    // Uncomment the following to create the token on Solo's SDK compatibility consensus port.
     // const client = Client.forNetwork({
     //   '127.0.0.1:50211': new AccountId(3),
     // });

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -10,7 +10,7 @@ const chains = {
     295: 'https://mainnet-public.mirrornode.hedera.com/api/v1/',
     296: 'https://testnet.mirrornode.hedera.com/api/v1/',
     297: 'https://previewnet.mirrornode.hedera.com/api/v1/',
-    298: 'http://localhost:5551/api/v1/',
+    298: 'http://localhost:38081/api/v1/',
 };
 
 /**

--- a/test/.anvil.js
+++ b/test/.anvil.js
@@ -14,7 +14,7 @@ const { spawn } = require('child_process');
  * ### Examples
  *
  * ```javascript
- * const anvilHost = await anvil('localhost:7546');
+ * const anvilHost = await anvil('http://localhost:37546');
  * console.log(anvilHost); // http://127.0.0.1:51319
  * ```
  *

--- a/test/hts.e2e.js
+++ b/test/hts.e2e.js
@@ -199,8 +199,6 @@ describe('::e2e', function () {
             tests() {
                 const nonAssocAddress0 = '0x0000000000000000000000000000000001234567';
                 const nonAssocAddress1 = '0xdadB0d80178819F2319190D340ce9A924f783711';
-                // eslint-disable-next-line @typescript-eslint/no-this-alias
-                const self = this;
 
                 it("should retrieve token's `name`, `symbol` and `totalSupply`", async function () {
                     expect(await ERC20['name']()).to.be.equal(ft.name);

--- a/test/hts.e2e.js
+++ b/test/hts.e2e.js
@@ -43,7 +43,7 @@ async function waitForTx(promise) {
 }
 
 const OPTS = {
-    gasLimit: 500_000,
+    gasLimit: 1_000_000,
 };
 
 const network = {
@@ -65,16 +65,18 @@ const network = {
 const toAddress = accountId =>
     '0x' + parseInt(accountId.replace('0.0.', '')).toString(16).padStart(40, '0');
 
+const treasuryAccount = {
+    id: '0.0.1002',
+    evmAddress: '0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69',
+    privateKey: '0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524',
+};
+
 const ft = {
     name: 'Random FT Token',
     symbol: 'RFT',
     totalSupply: 5_000_000,
     decimals: 3,
-    treasury: {
-        id: '0.0.1011',
-        evmAddress: toAddress('0.0.1011'),
-        privateKey: '0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7',
-    },
+    treasury: treasuryAccount,
 };
 
 const aliasKeys = /**@type{const}*/ ([
@@ -212,9 +214,9 @@ describe('::e2e', function () {
                     expect(value).to.be.equal(BigInt(ft.totalSupply));
                 });
 
-                it('should retrieve zero `balanceOf` for existing non-associated accounts', async function () {
-                    expect(await ERC20['balanceOf'](toAddress('0.0.1002'))).to.be.equal(0n);
-                    expect(await ERC20['balanceOf'](wallets[1002].address)).to.be.equal(0n);
+                it('should retrieve zero `balanceOf` for non-associated accounts', async function () {
+                    expect(await ERC20['balanceOf'](wallets[1004].address)).to.be.equal(0n);
+                    expect(await ERC20['balanceOf'](wallets[1005].address)).to.be.equal(0n);
                 });
 
                 it('should get it `isAssociated` for treasury account', async function () {
@@ -224,10 +226,10 @@ describe('::e2e', function () {
 
                 it('should get not `isAssociated` for existing non-associated account', async function () {
                     expect(
-                        await ERC20['isAssociated']({ from: toAddress('0.0.1002') })
+                        await ERC20['isAssociated']({ from: toAddress('0.0.1004') })
                     ).to.be.equal(false);
                     expect(
-                        await ERC20['isAssociated']({ from: wallets[1002].address })
+                        await ERC20['isAssociated']({ from: wallets[1005].address })
                     ).to.be.equal(false);
                 });
 
@@ -250,13 +252,13 @@ describe('::e2e', function () {
                     if (self.tokenInfo === undefined) {
                         self.tokenInfo = tokenInfo;
                     } else {
-                        expect(self.tokenInfo).to.be.deep.equal(tokenInfo);
+                        expect(tokenInfo).to.be.deep.equal(self.tokenInfo);
                     }
                 });
 
                 it('should transfer from treasury to account and leave total supply untouched', async function () {
                     const amount = 200_000n;
-                    const alice = wallets[1002];
+                    const alice = wallets[1008];
 
                     const preTreasuryBalance = await ERC20['balanceOf'](ft.treasury.evmAddress);
                     expect(preTreasuryBalance).to.be.equal(BigInt(ft.totalSupply));

--- a/test/hts.e2e.js
+++ b/test/hts.e2e.js
@@ -46,6 +46,18 @@ const OPTS = {
     gasLimit: 500_000,
 };
 
+const network = {
+    consensusEndpoint: process.env['HEDERA_CONSENSUS_ENDPOINT'] ?? '127.0.0.1:50211',
+    nodeAccountId: process.env['HEDERA_NODE_ACCOUNT_ID'] ?? '0.0.3',
+    operatorId: process.env['OPERATOR_ID'] ?? '0.0.2',
+    operatorKey:
+        process.env['OPERATOR_KEY'] ??
+        '302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137',
+    jsonRpcRelayUrl: process.env['HEDERA_JSON_RPC_RELAY_URL'] ?? 'http://localhost:37546',
+    mirrorNodeUrl: process.env['MIRROR_NODE_URL'] ?? 'http://localhost:38081/api/v1/',
+    chainId: Number(process.env['HEDERA_CHAIN_ID'] ?? '298'),
+};
+
 /**
  * @param {string} accountId
  * @returns
@@ -59,23 +71,23 @@ const ft = {
     totalSupply: 5_000_000,
     decimals: 3,
     treasury: {
-        id: '0.0.1021',
+        id: '0.0.1011',
         evmAddress: '0x17b2b8c63fa35402088640e426c6709a254c7ffb',
         privateKey: '0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7',
     },
 };
 
 const aliasKeys = /**@type{const}*/ ([
-    [1012, '0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524'],
-    [1013, '0x2e1d968b041d84dd120a5860cee60cd83f9374ef527ca86996317ada3d0d03e7'],
-    [1014, '0x45a5a7108a18dd5013cf2d5857a28144beadc9c70b3bdbd914e38df4e804b8d8'],
-    [1015, '0x6e9d61a325be3f6675cf8b7676c70e4a004d2308e3e182370a41f5653d52c6bd'],
-    [1016, '0x0b58b1bd44469ac9f813b5aeaf6213ddaea26720f0b2f133d08b6f234130a64f'],
-    [1017, '0x95eac372e0f0df3b43740fa780e62458b2d2cc32d6a440877f1cc2a9ad0c35cc'],
-    [1018, '0x6c6e6727b40c8d4b616ab0d26af357af09337299f09c66704146e14236972106'],
-    [1019, '0x5072e7aa1b03f531b4731a32a021f6a5d20d5ddc4e55acbb71ae202fc6f3a26d'],
-    [1020, '0x60fe891f13824a2c1da20fb6a14e28fa353421191069ba6b6d09dd6c29b90eff'],
-    [1021, '0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7'],
+    [1002, '0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524'],
+    [1003, '0x2e1d968b041d84dd120a5860cee60cd83f9374ef527ca86996317ada3d0d03e7'],
+    [1004, '0x45a5a7108a18dd5013cf2d5857a28144beadc9c70b3bdbd914e38df4e804b8d8'],
+    [1005, '0x6e9d61a325be3f6675cf8b7676c70e4a004d2308e3e182370a41f5653d52c6bd'],
+    [1006, '0x0b58b1bd44469ac9f813b5aeaf6213ddaea26720f0b2f133d08b6f234130a64f'],
+    [1007, '0x95eac372e0f0df3b43740fa780e62458b2d2cc32d6a440877f1cc2a9ad0c35cc'],
+    [1008, '0x6c6e6727b40c8d4b616ab0d26af357af09337299f09c66704146e14236972106'],
+    [1009, '0x5072e7aa1b03f531b4731a32a021f6a5d20d5ddc4e55acbb71ae202fc6f3a26d'],
+    [1010, '0x60fe891f13824a2c1da20fb6a14e28fa353421191069ba6b6d09dd6c29b90eff'],
+    [1011, '0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7'],
 ]);
 
 /**
@@ -84,13 +96,10 @@ const aliasKeys = /**@type{const}*/ ([
  * @returns
  */
 async function createToken({ noSupplyKey } = {}) {
-    // https://github.com/hashgraph/hedera-local-node?tab=readme-ov-file#network-variables
-    const accountId = '0.0.2';
-    const privateKey =
-        '302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137';
-
-    const client = Client.forNetwork({ '127.0.0.1:50211': '0.0.3' })
-        .setOperator(accountId, PrivateKey.fromStringDer(privateKey))
+    const client = Client.forNetwork({
+        [network.consensusEndpoint]: network.nodeAccountId,
+    })
+        .setOperator(network.operatorId, PrivateKey.fromStringDer(network.operatorKey))
         .setDefaultMaxTransactionFee(new Hbar(100))
         .setDefaultMaxQueryPayment(new Hbar(50));
     let transaction = new TokenCreateTransaction()
@@ -99,7 +108,7 @@ async function createToken({ noSupplyKey } = {}) {
         .setTreasuryAccountId(ft.treasury.id)
         .setInitialSupply(ft.totalSupply)
         .setDecimals(ft.decimals)
-        .setAdminKey(PrivateKey.fromStringDer(privateKey));
+        .setAdminKey(PrivateKey.fromStringDer(network.operatorKey));
     if (!noSupplyKey) {
         transaction = transaction.setSupplyKey(PrivateKey.fromStringECDSA(ft.treasury.privateKey));
     }
@@ -125,11 +134,23 @@ function sleep(time, why) {
     return new Promise(resolve => setTimeout(resolve, time));
 }
 
-describe('::e2e', function () {
-    this.timeout(60000);
+/**
+ * @param {string} title
+ * @param {string} tokenId
+ * @returns {Promise<any>}
+ */
+async function waitForMirrorToken(title, tokenId) {
+    for (let i = 1; i <= 30; i++) {
+        const token = await (await fetch(`${network.mirrorNodeUrl}tokens/${tokenId}`)).json();
+        if (!('_status' in token)) return token;
+        await sleep(2000, `Waiting for token "${title}" to propagate to Mirror Node`);
+    }
 
-    const jsonRpcRelayUrl = 'http://localhost:7546';
-    const mirrorNodeUrl = 'http://localhost:5551/api/v1/';
+    return (await fetch(`${network.mirrorNodeUrl}tokens/${tokenId}`)).json();
+}
+
+describe('::e2e', function () {
+    this.timeout(120000);
 
     /** @type {string} */
     let anvilHost;
@@ -143,14 +164,16 @@ describe('::e2e', function () {
             console.info(`Token "${suite.title}" ${suite.tokenId} @ ${suite.tokenAddress} created`);
         }
 
-        await sleep(2000, `Waiting for tokens to propagate to Mirror Node`);
-
         for (const { title, tokenId } of suites) {
-            const token = await (await fetch(`${mirrorNodeUrl}tokens/${tokenId}`)).json();
+            const token = await waitForMirrorToken(title, tokenId);
             expect('_status' in token, `Token "${title}" \`${tokenId}\` not found`).to.be.false;
         }
 
-        const { host: forwarderUrl } = await jsonRPCForwarder(jsonRpcRelayUrl, mirrorNodeUrl, 298);
+        const { host: forwarderUrl } = await jsonRPCForwarder(
+            network.jsonRpcRelayUrl,
+            network.mirrorNodeUrl,
+            network.chainId
+        );
         anvilHost = await anvil(forwarderUrl);
 
         // Ensure HTS emulation is reachable
@@ -204,7 +227,7 @@ describe('::e2e', function () {
                         await ERC20['isAssociated']({ from: toAddress('0.0.1002') })
                     ).to.be.equal(false);
                     expect(
-                        await ERC20['isAssociated']({ from: wallets[1012].address })
+                        await ERC20['isAssociated']({ from: wallets[1002].address })
                     ).to.be.equal(false);
                 });
 
@@ -233,7 +256,7 @@ describe('::e2e', function () {
 
                 it('should transfer from treasury to account and leave total supply untouched', async function () {
                     const amount = 200_000n;
-                    const alice = wallets[1012];
+                    const alice = wallets[1002];
 
                     const preTreasuryBalance = await ERC20['balanceOf'](ft.treasury.evmAddress);
                     expect(preTreasuryBalance).to.be.equal(BigInt(ft.totalSupply));
@@ -308,10 +331,10 @@ describe('::e2e', function () {
     suites.forEach(suite =>
         describe(suite.title, function () {
             [
-                /**@type{const}*/ (['anvil/local-node', () => anvilHost]),
-                /**@type{const}*/ (['local-node', () => jsonRpcRelayUrl]),
-            ].forEach(([network, host]) => {
-                describe(network, function () {
+                /**@type{const}*/ (['anvil/solo', () => anvilHost]),
+                /**@type{const}*/ (['solo', () => network.jsonRpcRelayUrl]),
+            ].forEach(([networkName, host]) => {
+                describe(networkName, function () {
                     before(async function () {
                         tokenAddress = suite.tokenAddress;
                         const rpc = new JsonRpcProvider(host(), undefined, { batchMaxCount: 1 });

--- a/test/hts.e2e.js
+++ b/test/hts.e2e.js
@@ -246,16 +246,6 @@ describe('::e2e', function () {
                     );
                 });
 
-                // To enable this, we need to change `getTokenInfo` to a `view` function
-                it("should retrieve token's metadata through `getTokenInfo`", async function () {
-                    const tokenInfo = await HTS['getTokenInfo'](tokenAddress);
-                    if (self.tokenInfo === undefined) {
-                        self.tokenInfo = tokenInfo;
-                    } else {
-                        expect(tokenInfo).to.be.deep.equal(self.tokenInfo);
-                    }
-                });
-
                 it('should transfer from treasury to account and leave total supply untouched', async function () {
                     const amount = 200_000n;
                     const alice = wallets[1008];

--- a/test/hts.e2e.js
+++ b/test/hts.e2e.js
@@ -72,7 +72,7 @@ const ft = {
     decimals: 3,
     treasury: {
         id: '0.0.1011',
-        evmAddress: '0x17b2b8c63fa35402088640e426c6709a254c7ffb',
+        evmAddress: toAddress('0.0.1011'),
         privateKey: '0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7',
     },
 };
@@ -212,9 +212,9 @@ describe('::e2e', function () {
                     expect(value).to.be.equal(BigInt(ft.totalSupply));
                 });
 
-                it('should retrieve zero `balanceOf` for non-associated accounts', async function () {
-                    expect(await ERC20['balanceOf'](nonAssocAddress0)).to.be.equal(0n);
-                    expect(await ERC20['balanceOf'](nonAssocAddress1)).to.be.equal(0n);
+                it('should retrieve zero `balanceOf` for existing non-associated accounts', async function () {
+                    expect(await ERC20['balanceOf'](toAddress('0.0.1002'))).to.be.equal(0n);
+                    expect(await ERC20['balanceOf'](wallets[1002].address)).to.be.equal(0n);
                 });
 
                 it('should get it `isAssociated` for treasury account', async function () {
@@ -263,6 +263,7 @@ describe('::e2e', function () {
                     expect(await ERC20['balanceOf'](alice.address)).to.be.equal(0n);
                     const preTotalSupply = await ERC20['totalSupply']();
 
+                    await waitForTx(sendAs(ERC20, alice)['associate'](OPTS));
                     await waitForTx(
                         sendAs(ERC20, treasury)['transfer'](alice.address, amount, OPTS)
                     );

--- a/test/scripts/json-rpc-mock.js
+++ b/test/scripts/json-rpc-mock.js
@@ -192,8 +192,10 @@ const eth = {
      * https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_getblockbynumber
      * @type {EthHandler}
      */
-    eth_getBlockByNumber: async ([blockNumber, _transactionDetails]) =>
-        require(`./eth_getBlockByNumber_${blockNumber}.json`),
+    eth_getBlockByNumber: async ([blockNumber, _transactionDetails]) => {
+        if (blockNumber === 'latest') blockNumber = await eth.eth_blockNumber([]);
+        return require(`./eth_getBlockByNumber_${blockNumber}.json`);
+    },
 
     /**
      * https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_gettransactioncount
@@ -211,6 +213,19 @@ const eth = {
             : typeof address === 'string' && isHIP719Contract(address)
               ? getHIP719Code(address)
               : '0x',
+
+
+    /**
+     * Anvil asks fork providers for aggregate account data during fork setup.
+     *
+     * https://github.com/foundry-rs/foundry/pull/10496
+     * @type {EthHandler}
+     */
+    eth_getAccountInfo: async ([address, blockNumber]) => ({
+        balance: await eth.eth_getBalance([address, blockNumber]),
+        nonce: await eth.eth_getTransactionCount([address, blockNumber]),
+        code: await eth.eth_getCode([address, blockNumber]),
+    }),
 
     /**
      * https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_getbalance


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR migrates the repo’s local Hedera network usage from legacy local-node tooling to Solo.

* Add a reusable Solo Falcon setup action for CI
* Deploy Solo in local-network CI jobs and destroy the same Falcon deployment during cleanup
* Upload Solo logs from CI jobs for easier failure diagnosis
* Replace local-node package scripts with Solo deploy and destroy scripts
* Remove `@hashgraph/hedera-local` and declare `ansi-colors` explicitly
* Update Foundry, e2e, plugin, and Mirror FFI local endpoints to Solo defaults
* Update e2e account assumptions to Solo predefined alias accounts
* Refresh README and internal docs for Solo, Kind, and the new local endpoints


**Related issue(s)**:

Fixes #303 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
